### PR TITLE
Add venteliste link to admin sidebar

### DIFF
--- a/enkelparkering/admin/admin_layout.php
+++ b/enkelparkering/admin/admin_layout.php
@@ -44,6 +44,7 @@ if ($user['rolle'] !== 'admin') {
         <li><a href="admin_anlegg.php">🅿️ Anlegg</a></li>
         <li><a href="admin_plasser.php">📋 Plasser</a></li>
         <li><a href="admin_brukere.php">👥 Brukere</a></li>
+        <li><a href="admin_venteliste.php">⏳ Venteliste</a></li>
       </ul>
     </aside>
 


### PR DESCRIPTION
## Summary
- Add venteliste navigation link to admin sidebar

## Testing
- `php -l enkelparkering/admin/admin_layout.php`


------
https://chatgpt.com/codex/tasks/task_e_68b9ffc1ee148327a63055ec80dff5e8