### PR TITLE
Make site mobile friendly

### DIFF
--- a/enkelparkering/admin/admin.css
+++ b/enkelparkering/admin/admin.css
@@ -158,3 +158,30 @@ form button {
 form button:hover {
   background: #192a56;
 }
+
+/* === Responsive === */
+@media (max-width: 768px) {
+  .dashboard {
+    flex-direction: column;
+    height: auto;
+  }
+
+  .sidebar {
+    flex: none;
+    width: 100%;
+  }
+
+  .content {
+    flex: none;
+    width: 100%;
+  }
+
+  .admin-container {
+    flex-direction: column;
+  }
+
+  .admin-container .map-area {
+    flex: none;
+    height: 50vh;
+  }
+}

--- a/enkelparkering/admin/admin_layout.php
+++ b/enkelparkering/admin/admin_layout.php
@@ -24,6 +24,7 @@ if ($user['rolle'] !== 'admin') {
 <html lang="no">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title><?= $title ?? 'Adminpanel' ?> – EnkelParkering</title>
   <link rel="stylesheet" href="admin.css">
 </head>

--- a/enkelparkering/index.php
+++ b/enkelparkering/index.php
@@ -45,6 +45,7 @@ $anlegg = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
 <html lang="no">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Hjem – EnkelParkering</title>
   <link rel="stylesheet" href="style.css">
   <link rel="stylesheet" href="https://unpkg.com/leaflet/dist/leaflet.css" />

--- a/enkelparkering/login.php
+++ b/enkelparkering/login.php
@@ -61,6 +61,7 @@ if (isset($_POST['register'])) {
 <html lang="no">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Logg inn – EnkelParkering</title>
   <style>
     body {
@@ -71,13 +72,15 @@ if (isset($_POST['register'])) {
       justify-content: center;
       align-items: center;
       height: 100vh;
+      padding: 1rem;
     }
     .login-container {
       background: white;
       padding: 2rem;
       border-radius: 8px;
       box-shadow: 0 2px 6px rgba(0,0,0,0.1);
-      width: 320px;
+      width: 90%;
+      max-width: 320px;
     }
     .login-container h1 {
       text-align: center;

--- a/enkelparkering/min_venteliste.php
+++ b/enkelparkering/min_venteliste.php
@@ -48,6 +48,7 @@ $oppføring = $stmt->get_result()->fetch_assoc();
 <html lang="no">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Min venteliste – EnkelParkering</title>
   <link rel="stylesheet" href="style.css">
 </head>

--- a/enkelparkering/style.css
+++ b/enkelparkering/style.css
@@ -138,3 +138,28 @@ button[disabled] {
   border-radius: 6px;
   font-size: 0.9rem;
 }
+
+/* === Responsive === */
+@media (max-width: 768px) {
+  .dashboard {
+    flex-direction: column;
+    height: auto;
+  }
+
+  .map-area {
+    flex: none;
+    height: 50vh;
+  }
+
+  .sidebar {
+    flex: none;
+    width: 100%;
+    border-left: none;
+    border-top: 1px solid #ddd;
+  }
+
+  .header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}

--- a/indexlink.html
+++ b/indexlink.html
@@ -2,6 +2,7 @@
 <html lang="no">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Mine mapper</title>
   <style>
     body {


### PR DESCRIPTION
## Summary
- Add viewport meta tags to public and admin pages for proper mobile scaling
- Introduce responsive media queries for main and admin layouts
- Adjust login form styling to adapt to narrow screens

## Testing
- `php -l enkelparkering/index.php`
- `php -l enkelparkering/login.php`
- `php -l enkelparkering/min_venteliste.php`
- `php -l enkelparkering/admin/admin_layout.php`


------
https://chatgpt.com/codex/tasks/task_e_68bc652593b883279d464ca0414f21c7