### PR TITLE
Add sell preview toggle on crypto order cards

### DIFF
--- a/crypto-tracker/assets/style.css
+++ b/crypto-tracker/assets/style.css
@@ -332,6 +332,27 @@ header h1 {
     flex-wrap: wrap;
 }
 
+.order-card__preview {
+    margin-top: 12px;
+    padding-top: 12px;
+    border-top: 1px dashed var(--border);
+    display: grid;
+    gap: 10px;
+}
+
+.preview-row {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.preview-result {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+}
+
 .order-card.status-open { border-left: 3px solid var(--accent); }
 .order-card.status-closed { border-left: 3px solid var(--success); }
 

--- a/crypto-tracker/index.php
+++ b/crypto-tracker/index.php
@@ -238,6 +238,7 @@ if (!empty($orders)) {
                     ?>
                     <article class="order-card <?php echo $isClosed ? 'status-closed' : 'status-open'; ?>"
                              data-entry-price="<?php echo formatDecimal($order['entry_price']); ?>"
+                             data-quantity="<?php echo formatDecimal($order['quantity']); ?>"
                              data-remaining="<?php echo formatDecimal($order['remaining_quantity']); ?>"
                              data-asset="<?php echo h(strtolower($order['asset'])); ?>"
                              data-asset-symbol="<?php echo h($assetSymbol); ?>"
@@ -278,6 +279,9 @@ if (!empty($orders)) {
                         <div class="order-card__actions">
                             <a class="btn ghost" href="order_detail.php?id=<?php echo (int)$order['id']; ?>">Details</a>
                             <?php if (!$isClosed): ?>
+                                <button class="btn ghost preview-toggle" type="button" aria-expanded="false">
+                                    Forhåndsvis salg
+                                </button>
                                 <button class="btn secondary open-close-modal" type="button"
                                         data-order-id="<?php echo (int)$order['id']; ?>"
                                         data-asset="<?php echo h($order['asset']); ?>"
@@ -288,6 +292,21 @@ if (!empty($orders)) {
                                 </button>
                             <?php endif; ?>
                         </div>
+                        <?php if (!$isClosed): ?>
+                            <div class="order-card__preview" hidden>
+                                <div class="preview-row">
+                                    <label for="preview-price-<?php echo (int)$order['id']; ?>">Pris for salg</label>
+                                    <div class="input-with-addon">
+                                        <input type="number" step="0.00000001" min="0" class="preview-price-input" id="preview-price-<?php echo (int)$order['id']; ?>" placeholder="0">
+                                        <span class="input-addon"><?php echo h(strtoupper($order['currency'] ?? 'USD')); ?></span>
+                                    </div>
+                                </div>
+                                <div class="preview-result">
+                                    <p class="eyebrow">Fortjeneste</p>
+                                    <p class="mono profit preview-profit">-</p>
+                                </div>
+                            </div>
+                        <?php endif; ?>
                     </article>
                 <?php endforeach; ?>
             <?php else: ?>


### PR DESCRIPTION
### Motivation

- Gi brukeren en enkel «forhåndsvis salg/close» på hvert ordre-kort for å teste forskjellige salgskurser og se forventet fortjeneste uten å gjennomføre en lukking.

### Description

- La til en `Forhåndsvis salg` knapp og et skjult preview-panel på åpne ordre-kort som inneholder en pris-input og et fortjeneste-felt; endringer i `index.php` oppdaterer markup og data-attributter.
- Implementerte klient-side logikk i `assets/app.js`: `computeRemainingCostBasis`, `updatePreviewProfit` og event-handlere som åpner/pakker preview-panelet og regner ut fortjeneste basert på `remaining`, `quantity`, `entryPrice` eller `totalCost`.
- La til enkel styling for preview-panelet i `assets/style.css` for å passe inn i kortlayouten.
- Endrede filer: `index.php`, `assets/app.js`, `assets/style.css`.

### Testing

- Startet den innebygde PHP-dev-serveren med `php -S 0.0.0.0:8000 -t /workspace/web/crypto-tracker` og serveren startet suksessfullt.
- Kjørte et Playwright-skript som åpnet `http://127.0.0.1:8000/index.php` og tok en fullside-skjermdump (`artifacts/crypto-tracker-preview.png`), og skriptet fullførte uten feil.
- Ingen automatiserte enhetstester ble kjørt siden endringen er UI/JS-orientert.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69827cbf67208327b317158f3c72e818)