### PR TITLE
Forbedre detaljgraf for måletyper med periodefilter og innsikter

### DIFF
--- a/treningslogg/style.css
+++ b/treningslogg/style.css
@@ -637,6 +637,70 @@ h1 {
   fill: #1f2937;
 }
 
+
+.chart-large .chart-area {
+  fill: url(#chartFill);
+  stroke: none;
+}
+
+.chart-large .chart-trend {
+  stroke: #7c3aed;
+  stroke-width: 2;
+  stroke-dasharray: 7 6;
+}
+
+.chart-large .chart-average {
+  stroke: rgba(29, 78, 216, 0.45);
+  stroke-width: 1.5;
+  stroke-dasharray: 5 5;
+}
+
+.range-tabs {
+  display: inline-flex;
+  gap: 8px;
+  padding: 4px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: #f8fafc;
+}
+
+.range-tab {
+  text-decoration: none;
+  color: var(--muted);
+  font-size: 13px;
+  font-weight: 600;
+  padding: 7px 12px;
+  border-radius: 999px;
+}
+
+.range-tab.active {
+  color: #fff;
+  background: var(--primary);
+}
+
+.detail-stats {
+  display: grid;
+  gap: 10px;
+}
+
+.detail-card {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 12px;
+  display: grid;
+  gap: 4px;
+  background: #fcfdff;
+}
+
+.detail-card strong {
+  font-size: 18px;
+}
+
+.detail-card span {
+  color: var(--muted);
+  font-size: 13px;
+}
+
 .entry-list ul {
   list-style: none;
   display: grid;
@@ -767,5 +831,9 @@ h1 {
 
   .measurement-detail > * {
     flex: 1;
+  }
+
+  .detail-stats {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 }


### PR DESCRIPTION
### Motivation
- Gi brukeren bedre og mer lesbar visualisering av utvikling per måling ved å legge til periodefilter, trend og nøkkeltall på detaljsidene.
- Gjøre statistikk og enkle analyser tilgjengelig klient-side uten å endre databasestruktur.

### Description
- La til periodefilter (30 dager / 90 dager / Alle) og hente større datagrunnlag med `fetch_entries(..., 300)` i `treningslogg/measurement.php` slik at grafen kan vises for valgt tidsperiode og filteret bevares ved sletting av registreringer.
- Beregner og viser nøkkeltall i `measurement.php`: endring i valgt periode (cm og %), gjennomsnitt, min, maks og registreringsfrekvens (snitt dager mellom målinger).
- Tegner forbedret graf i `measurement.php` inkludert fylt areagraf, glattet trendlinje (3-punkts glidende snitt), og horisontal snittlinje; legger til en SVG-gradient og ekstra elementer for trend/areal/snitt.
- Legger til hjelpefunksjoner i `treningslogg/lib.php`: `summarize_measurement_entries(array $entries)` og `calculate_moving_average_points(array $entries, int $window = 3)` for gjenbrukbar analyse og beregning av trendpunkter.
- Oppdaterer `treningslogg/style.css` med styling for nye grafelementer, `range-tabs`, og `detail-stats`/`detail-card` for responsiv visning av nøkkeltall.

### Testing
- Kjørte PHP lint på endrede filer med `php -l treningslogg/lib.php` og `php -l treningslogg/measurement.php`; begge returnerte ingen syntax-feil (suksess).
- Startet dev-server og tok et automatisert skjermbilde via headless browser for verifisering; skjermbildet ble lagret, men et forsøk med `curl -I` mot ruten returnerte `500 Internal Server Error` i dette miljøet, så full rendering i servermiljøet kunne ikke bekreftes end-to-end.
- Ingen nye enhetstester ble lagt til i dette endringssettet.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e4a4a28b883278026bbbc8ced5052)