### PR TITLE
Venteliste UX, resend tilbud (admin), adresse-basert nærmeste ledig plass og mobiljusteringer

### DIFF
--- a/enkelparkering/admin/admin_venteliste.php
+++ b/enkelparkering/admin/admin_venteliste.php
@@ -131,6 +131,10 @@ unset($_SESSION['admin_message']);
               <button disabled>Ingen ledig</button>
             <?php endif; ?>
           <?php elseif ($kontrakt['status'] === 'tilbud'): ?>
+            <form method="post" action="send_tilbud_pa_nytt.php" class="inline-form">
+              <input type="hidden" name="kontrakt_id" value="<?= $kontrakt['id'] ?>">
+              <button type="submit">🔁 Send tilbud på nytt</button>
+            </form>
             <form method="post" action="kontrakt_last_opp.php" enctype="multipart/form-data" class="inline-form">
               <input type="hidden" name="kontrakt_id" value="<?= $kontrakt['id'] ?>">
               <label>Signert kontrakt

--- a/enkelparkering/admin/send_tilbud_pa_nytt.php
+++ b/enkelparkering/admin/send_tilbud_pa_nytt.php
@@ -1,0 +1,133 @@
+<?php
+session_start();
+include_once $_SERVER['DOCUMENT_ROOT'] . '/db.php';
+require_once __DIR__ . '/../lib/PdfGenerator.php';
+
+if (!isset($_SESSION['user_id'])) {
+    header('Location: ../login.php');
+    exit;
+}
+
+$user_id = $_SESSION['user_id'];
+$stmt = $conn->prepare('SELECT rolle, borettslag_id FROM users WHERE id = ?');
+$stmt->bind_param('i', $user_id);
+$stmt->execute();
+$admin = $stmt->get_result()->fetch_assoc();
+
+if (!$admin || $admin['rolle'] !== 'admin') {
+    die('Ingen tilgang.');
+}
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    header('Location: admin_venteliste.php');
+    exit;
+}
+
+$kontrakt_id = (int)($_POST['kontrakt_id'] ?? 0);
+if (!$kontrakt_id) {
+    $_SESSION['admin_message'] = 'Mangler kontrakt-ID.';
+    header('Location: admin_venteliste.php');
+    exit;
+}
+
+$stmt = $conn->prepare('SELECT k.*, v.user_id, u.navn, u.epost, p.nummer AS plass_nummer, a.navn AS anlegg_navn, a.type AS anlegg_type
+                        FROM kontrakter k
+                        JOIN venteliste v ON v.id = k.venteliste_id
+                        JOIN users u ON u.id = v.user_id
+                        JOIN plasser p ON p.id = k.plass_id
+                        JOIN anlegg a ON a.id = k.anlegg_id
+                        WHERE k.id = ? AND v.borettslag_id = ?
+                        LIMIT 1');
+$stmt->bind_param('ii', $kontrakt_id, $admin['borettslag_id']);
+$stmt->execute();
+$kontrakt = $stmt->get_result()->fetch_assoc();
+
+if (!$kontrakt) {
+    $_SESSION['admin_message'] = 'Fant ikke kontrakten.';
+    header('Location: admin_venteliste.php');
+    exit;
+}
+
+if ($kontrakt['status'] !== 'tilbud') {
+    $_SESSION['admin_message'] = 'Tilbud kan kun sendes på nytt når status er "tilbud".';
+    header('Location: admin_venteliste.php');
+    exit;
+}
+
+$depositum = 0;
+$maanedspris = 0;
+if ($prisStmt = $conn->prepare('SELECT depositum, leiepris FROM plass_priser WHERE type = ? LIMIT 1')) {
+    $prisStmt->bind_param('s', $kontrakt['anlegg_type']);
+    $prisStmt->execute();
+    $pris = $prisStmt->get_result()->fetch_assoc();
+    if ($pris) {
+        $depositum = (int)$pris['depositum'];
+        $maanedspris = (int)$pris['leiepris'];
+    }
+}
+
+$kontraktDir = __DIR__ . '/../kontrakter';
+if (!is_dir($kontraktDir)) {
+    mkdir($kontraktDir, 0777, true);
+}
+
+$pdfFilnavn = sprintf('tilbud_%d_%s.pdf', $kontrakt_id, date('Ymd_His'));
+$pdfPath = $kontraktDir . '/' . $pdfFilnavn;
+
+try {
+    PdfGenerator::createContractOffer($pdfPath, [
+        'name' => $kontrakt['navn'],
+        'facility' => $kontrakt['anlegg_navn'],
+        'place' => $kontrakt['plass_nummer'],
+        'type' => $kontrakt['anlegg_type'],
+        'deposit' => $depositum,
+        'monthly' => $maanedspris,
+        'date' => date('d.m.Y')
+    ]);
+    $pdfAttachment = chunk_split(base64_encode(file_get_contents($pdfPath)));
+} catch (Throwable $e) {
+    $pdfAttachment = null;
+}
+
+$subject = 'Tilbud om parkeringsplass – ' . $kontrakt['anlegg_navn'];
+$body = "Hei {$kontrakt['navn']},\r\n\r\n" .
+    "Vi sender tilbudet ditt på nytt for parkeringsplass {$kontrakt['plass_nummer']} på {$kontrakt['anlegg_navn']}. " .
+    "Vedlagt finner du standardkontrakten med generell informasjon om bruk av plassen, hærverk og betalingsbetingelser.\r\n\r\n" .
+    "Signer kontrakten og svar på denne e-posten med signert kopi for å bekrefte plassen.\r\n\r\n" .
+    "Med vennlig hilsen\r\n" .
+    "Parkeringsansvarlig";
+
+if ($pdfAttachment) {
+    $boundary = '=_Part_' . md5((string)microtime(true));
+    $headers = "From: noreply@enkelparkering.test\r\n";
+    $headers .= "MIME-Version: 1.0\r\n";
+    $headers .= "Content-Type: multipart/mixed; boundary=\"{$boundary}\"";
+
+    $message = "--{$boundary}\r\n";
+    $message .= "Content-Type: text/plain; charset=\"utf-8\"\r\n";
+    $message .= "Content-Transfer-Encoding: 8bit\r\n\r\n";
+    $message .= $body . "\r\n\r\n";
+    $message .= "--{$boundary}\r\n";
+    $message .= "Content-Type: application/pdf; name=\"kontraktstilbud.pdf\"\r\n";
+    $message .= "Content-Transfer-Encoding: base64\r\n";
+    $message .= "Content-Disposition: attachment; filename=\"kontraktstilbud.pdf\"\r\n\r\n";
+    $message .= $pdfAttachment . "\r\n";
+    $message .= "--{$boundary}--";
+
+    $mail_ok = @mail($kontrakt['epost'], $subject, $message, $headers);
+} else {
+    $headers = 'From: noreply@enkelparkering.test';
+    $mail_ok = @mail($kontrakt['epost'], $subject, $body, $headers);
+}
+
+if ($mail_ok) {
+    $stmt = $conn->prepare('UPDATE kontrakter SET tilbudt_dato = NOW() WHERE id = ?');
+    $stmt->bind_param('i', $kontrakt_id);
+    $stmt->execute();
+    $_SESSION['admin_message'] = 'Tilbud sendt på nytt til ' . $kontrakt['navn'] . '.';
+} else {
+    $_SESSION['admin_message'] = 'Klarte ikke å sende tilbud på nytt automatisk.';
+}
+
+header('Location: admin_venteliste.php');
+exit;

--- a/enkelparkering/docs/users_adresse_migration.sql
+++ b/enkelparkering/docs/users_adresse_migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE users
+ADD COLUMN adresse VARCHAR(255) NULL AFTER epost;

--- a/enkelparkering/index.php
+++ b/enkelparkering/index.php
@@ -17,11 +17,13 @@ $stmt->execute();
 $user = $stmt->get_result()->fetch_assoc();
 
 // Sjekk om bruker står på ventelisten
-$stmt = $conn->prepare("SELECT id FROM venteliste WHERE user_id = ? AND borettslag_id = ?");
+$stmt = $conn->prepare("SELECT id, anlegg_id FROM venteliste WHERE user_id = ? AND borettslag_id = ?");
 $stmt->bind_param("ii", $user_id, $user['borettslag_id']);
 $stmt->execute();
 $venteliste_entry = $stmt->get_result()->fetch_assoc();
 $er_på_venteliste = !empty($venteliste_entry);
+$venteliste_anlegg_id = isset($venteliste_entry['anlegg_id']) ? (int)$venteliste_entry['anlegg_id'] : null;
+$har_global_venteliste = $er_på_venteliste && $venteliste_anlegg_id === 0;
 
 
 // Hent anlegg + oppsummering fra plasser
@@ -78,6 +80,18 @@ $anlegg = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
   </section>
   <aside class="sidebar">
   <h2>Anlegg</h2>
+    <?php if (empty($user['adresse'])): ?>
+      <p class="message">📍 Legg til adresse når du registrerer bruker/profil for å få forslag til nærmeste ledige plass.</p>
+    <?php else: ?>
+      <div class="facility-card nearest-card">
+        <h3>📍 Nærmeste ledige plass</h3>
+        <p id="nearestSpotInfo"
+           data-address="<?= htmlspecialchars($user['adresse']) ?>"
+           data-anlegg='<?= htmlspecialchars(json_encode($anlegg, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES), ENT_QUOTES, 'UTF-8') ?>'>
+          Finner nærmeste ledige plass basert på adressen din…
+        </p>
+      </div>
+    <?php endif; ?>
   <!-- Global venteliste-boks -->
     <form method="post" action="venteliste.php">
     <input type="hidden" name="anlegg_id" value="">
@@ -86,7 +100,11 @@ $anlegg = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
         Ønsker lader
     </label>
     <button type="submit" class="global-waitlist-button" <?= $er_på_venteliste ? 'disabled' : '' ?>>
-        <?= $er_på_venteliste ? '✔️ Du er på venteliste' : '➕ Meld meg på venteliste for første ledige plass i borettslaget' ?>
+        <?=
+          $har_global_venteliste
+            ? '✔️ Du står på venteliste for første ledige plass i borettslaget'
+            : ($er_på_venteliste ? 'Du står på venteliste for et spesifikt anlegg' : '➕ Meld meg på venteliste for første ledige plass i borettslaget')
+        ?>
     </button>
     </form>
 
@@ -108,7 +126,11 @@ $anlegg = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
             Ønsker lader
         </label>
         <button type="submit" <?= $er_på_venteliste ? 'disabled' : '' ?>>
-            <?= $er_på_venteliste ? '✔️ Du er på venteliste' : '➕ Meld meg på venteliste for dette anlegget' ?>
+            <?=
+              ($er_på_venteliste && $venteliste_anlegg_id === (int)$a['id'])
+                ? '✔️ Du står på venteliste for dette anlegget'
+                : ($er_på_venteliste ? 'Du står på venteliste for et annet valg' : '➕ Meld meg på venteliste for dette anlegget')
+            ?>
         </button>
         </form>
     </div>
@@ -159,6 +181,71 @@ $anlegg = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
       card.style.display = navn.includes(q) ? '' : 'none';
     });
   });
+
+  (function visNarmesteLedigPlass() {
+    var infoElement = document.getElementById('nearestSpotInfo');
+    if (!infoElement) return;
+
+    var adresse = infoElement.dataset.address;
+    var anleggListe = [];
+    try {
+      anleggListe = JSON.parse(infoElement.dataset.anlegg || '[]');
+    } catch (e) {
+      infoElement.textContent = 'Kunne ikke lese anleggsdata.';
+      return;
+    }
+
+    var kandidater = anleggListe.filter(function (a) {
+      return Number(a.ledige) > 0 && a.lat && a.lng;
+    });
+    if (!kandidater.length) {
+      infoElement.textContent = 'Ingen ledige plasser med kartposisjon er tilgjengelige akkurat nå.';
+      return;
+    }
+
+    var geoUrl = 'https://nominatim.openstreetmap.org/search?format=json&limit=1&q=' + encodeURIComponent(adresse);
+    fetch(geoUrl, { headers: { 'Accept': 'application/json' } })
+      .then(function (response) { return response.json(); })
+      .then(function (data) {
+        if (!Array.isArray(data) || !data.length) {
+          infoElement.textContent = 'Fant ikke koordinater for adressen din. Sjekk at adressen er komplett.';
+          return;
+        }
+
+        var brukerLat = Number(data[0].lat);
+        var brukerLng = Number(data[0].lon);
+        var naermest = null;
+
+        kandidater.forEach(function (a) {
+          var avstandKm = kalkulerAvstandKm(brukerLat, brukerLng, Number(a.lat), Number(a.lng));
+          if (!naermest || avstandKm < naermest.avstandKm) {
+            naermest = { navn: a.navn, avstandKm: avstandKm, ledige: Number(a.ledige) };
+          }
+        });
+
+        if (!naermest) {
+          infoElement.textContent = 'Fant ingen ledig plass med beregnbar avstand.';
+          return;
+        }
+
+        infoElement.innerHTML = '<strong>' + naermest.navn + '</strong> er nærmest med ledig plass (' +
+          naermest.avstandKm.toFixed(2) + ' km unna, ' + naermest.ledige + ' ledig).';
+      })
+      .catch(function () {
+        infoElement.textContent = 'Kunne ikke beregne avstand akkurat nå. Prøv igjen senere.';
+      });
+  })();
+
+  function kalkulerAvstandKm(lat1, lng1, lat2, lng2) {
+    var R = 6371;
+    var dLat = (lat2 - lat1) * Math.PI / 180;
+    var dLng = (lng2 - lng1) * Math.PI / 180;
+    var a = Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+      Math.cos(lat1 * Math.PI / 180) * Math.cos(lat2 * Math.PI / 180) *
+      Math.sin(dLng / 2) * Math.sin(dLng / 2);
+    var c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+    return R * c;
+  }
 </script>
 </body>
 </html>

--- a/enkelparkering/login.php
+++ b/enkelparkering/login.php
@@ -5,6 +5,14 @@ include_once $_SERVER['DOCUMENT_ROOT'] . '/db.php';
 // Meldinger
 $message = "";
 
+function harKolonne(mysqli $conn, string $tabell, string $kolonne): bool
+{
+    $stmt = $conn->prepare("SHOW COLUMNS FROM `$tabell` LIKE ?");
+    $stmt->bind_param("s", $kolonne);
+    $stmt->execute();
+    return $stmt->get_result()->num_rows > 0;
+}
+
 // Håndter innlogging
 if (isset($_POST['login'])) {
     $email = trim($_POST['email']);
@@ -35,6 +43,7 @@ if (isset($_POST['register'])) {
     $email = trim($_POST['email']);
     $passord = password_hash(trim($_POST['passord']), PASSWORD_DEFAULT);
     $kode = trim($_POST['kode']); // borettslagskode
+    $adresse = trim($_POST['adresse'] ?? '');
 
     $sql = "SELECT id FROM borettslag WHERE kode = ?";
     $stmt = $conn->prepare($sql);
@@ -44,9 +53,15 @@ if (isset($_POST['register'])) {
     $borettslag = $result->fetch_assoc();
 
     if ($borettslag) {
-        $sql = "INSERT INTO users (borettslag_id, navn, epost, passord, rolle) VALUES (?, ?, ?, ?, 'user')";
-        $stmt = $conn->prepare($sql);
-        $stmt->bind_param("isss", $borettslag['id'], $navn, $email, $passord);
+        if (harKolonne($conn, 'users', 'adresse')) {
+            $sql = "INSERT INTO users (borettslag_id, navn, epost, passord, rolle, adresse) VALUES (?, ?, ?, ?, 'user', ?)";
+            $stmt = $conn->prepare($sql);
+            $stmt->bind_param("issss", $borettslag['id'], $navn, $email, $passord, $adresse);
+        } else {
+            $sql = "INSERT INTO users (borettslag_id, navn, epost, passord, rolle) VALUES (?, ?, ?, ?, 'user')";
+            $stmt = $conn->prepare($sql);
+            $stmt->bind_param("isss", $borettslag['id'], $navn, $email, $passord);
+        }
         if ($stmt->execute()) {
             $subject = "Velkommen til EnkelParkering";
             $body = "Hei $navn,\n\nTakk for at du registrerte deg hos EnkelParkering. Du kan nå logge inn og administrere parkeringsplassene dine.\n\nVennlig hilsen\nEnkelParkering";
@@ -305,6 +320,7 @@ if ($result) {
       <input type="text" name="navn" placeholder="Navn" required>
       <input type="email" name="email" placeholder="E-post" required>
       <input type="password" name="passord" placeholder="Passord" required>
+      <input type="text" name="adresse" placeholder="Adresse (for nærmeste ledige plass)" required>
       <input type="text" name="kode" placeholder="Kode fra borettslaget" required>
       <button type="submit" name="register">Registrer bruker</button>
     </form>

--- a/enkelparkering/style.css
+++ b/enkelparkering/style.css
@@ -68,6 +68,10 @@ main,
   color: var(--text-muted);
 }
 
+.nearest-card {
+  margin-bottom: 1rem;
+}
+
 /* === Kort === */
 .facility-card {
   background: var(--surface);
@@ -355,18 +359,18 @@ button[disabled] {
 
   .map-area {
     flex: none;
-    height: 50vh;
-    padding: 1rem;
+    height: 42vh;
+    padding: 0.5rem;
   }
 
   .sidebar {
     flex: none;
-    width: 90%;
-    max-width: 90%;
+    width: 100%;
+    max-width: 100%;
     margin: 0 auto;
     border-left: none;
     border-top: none;
-    padding: 1.25rem;
+    padding: 0.9rem;
   }
 
   .header {
@@ -382,12 +386,14 @@ button[disabled] {
   }
 
   .search-box {
-    max-width: 480px;
-    margin: 1rem auto 0;
+    max-width: 100%;
+    margin: 0.5rem auto 0;
+    font-size: 16px;
   }
 
   .menu-toggle {
     display: block;
+    align-self: flex-end;
   }
 
   .nav {
@@ -404,5 +410,18 @@ button[disabled] {
 
   .header a {
     margin-left: 0;
+    width: 100%;
+    justify-content: center;
+  }
+
+  .facility-card {
+    padding: 1rem;
+    border-radius: 16px;
+  }
+
+  .facility-card button,
+  .global-waitlist-button {
+    min-height: 44px;
+    font-size: 0.92rem;
   }
 }


### PR DESCRIPTION
### Motivation
- Gjøre venteliste-tekster tydelige og kontekstspesifikke slik at «du er på venteliste» kun viser korrekt status per valg (global vs. spesifikt anlegg).
- Gi admin mulighet til å resendere tilbud dersom bruker ikke ser første e-post.
- Forbedre brukeropplevelsen ved å vise nærmeste ledige plass basert på brukeradresse og gjøre små mobiloptimaliseringer.

### Description
- Endret `enkelparkering/index.php` for å skille global venteliste vs. spesifikt anlegg, vise mer presise knapptekster og legge til en «Nærmeste ledige plass»-kort som geokoder brukerens `adresse` og beregner nærmeste anlegg med ledig plass i klient-side JS (Nominatim + Haversine).
- La til `enkelparkering/admin/send_tilbud_pa_nytt.php` som admin-endepunkt for å regenerere/vedlegge PDF (via `PdfGenerator`) og sende tilbud på nytt samt oppdatere `tilbudt_dato`, og la til knapp i `enkelparkering/admin/admin_venteliste.php`.
- Oppdatert `enkelparkering/login.php` for å be om `adresse` ved registrering og implementert `harKolonne()`-sjekk slik at innsending er bakoverkompatibel dersom `users.adresse` ikke finnes.
- Stil- og layoutforbedringer i `enkelparkering/style.css` for bedre mobilvisning (kort padding, fullbredde sidebar, større knappminstehøyde), og lagt ved SQL-migrasjon `enkelparkering/docs/users_adresse_migration.sql` for å legge til kolonnen `adresse`.

### Testing
- Kjørte syntaksjekk med `php -l` for `enkelparkering/index.php`, `enkelparkering/login.php`, `enkelparkering/admin/admin_venteliste.php` og `enkelparkering/admin/send_tilbud_pa_nytt.php`, alle viste `No syntax errors detected`.
- Ingen automatiserte integrasjonstester ble kjørt; endringene inkluderer en ny SQL-migrering som må kjøres i produksjon med `ALTER TABLE users ADD COLUMN adresse VARCHAR(255) NULL AFTER epost;` før adresse-funksjonalitet er fullt operativ.
- Client-side funksjon for nærmeste plass bruker eksternt geokoding-API (`https://nominatim.openstreetmap.org`), og forutsetter at anlegg har gyldige `lat/lng` og at nettleseren kan gjøre `fetch` til tjenesten.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de901e4d2483279cda4e05cbb1c986)