### PR TITLE
Forbedre ventelisteflyt og legg til visualisert admin-dashboard

### DIFF
--- a/enkelparkering/admin/admin.css
+++ b/enkelparkering/admin/admin.css
@@ -233,6 +233,70 @@ form button:hover {
   gap: 6px;
 }
 
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 14px;
+  margin: 18px 0;
+}
+
+.stat-card,
+.chart-card {
+  background: #fff;
+  border: 1px solid #dbe3ec;
+  border-radius: 10px;
+  padding: 14px;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+}
+
+.stat-card h3,
+.chart-card h3 {
+  margin: 0 0 8px;
+}
+
+.stat-number {
+  font-size: 2rem;
+  margin: 0;
+  font-weight: 700;
+  color: #1e3a5f;
+}
+
+.charts-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 14px;
+}
+
+.progress {
+  display: flex;
+  width: 100%;
+  height: 14px;
+  border-radius: 999px;
+  overflow: hidden;
+  background: #edf2f7;
+  margin: 10px 0 6px;
+}
+
+.segment {
+  height: 100%;
+}
+
+.segment.ledig {
+  background: #2ecc71;
+}
+
+.segment.opptatt {
+  background: #e74c3c;
+}
+
+.segment.global {
+  background: #4b7bec;
+}
+
+.segment.anlegg {
+  background: #f39c12;
+}
+
 /* === Responsive === */
 @media (max-width: 768px) {
   .dashboard {

--- a/enkelparkering/admin/admin.php
+++ b/enkelparkering/admin/admin.php
@@ -1,4 +1,120 @@
 <?php
 $title = "Dashboard";
-$content = "<h2>Velg en modul i menyen</h2>";
+
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+include_once $_SERVER['DOCUMENT_ROOT'] . '/db.php';
+
+$user_id = $_SESSION['user_id'] ?? null;
+$stmt = $conn->prepare("SELECT borettslag_id FROM users WHERE id = ? LIMIT 1");
+$stmt->bind_param("i", $user_id);
+$stmt->execute();
+$admin = $stmt->get_result()->fetch_assoc();
+$borettslag_id = (int)($admin['borettslag_id'] ?? 0);
+
+$stat = [
+    'brukere' => 0,
+    'anlegg' => 0,
+    'plasser_totalt' => 0,
+    'plasser_ledig' => 0,
+    'plasser_opptatt' => 0,
+    'venteliste_totalt' => 0,
+    'venteliste_global' => 0,
+    'venteliste_anlegg' => 0,
+];
+
+$stmt = $conn->prepare("SELECT COUNT(*) AS antall FROM users WHERE borettslag_id = ?");
+$stmt->bind_param("i", $borettslag_id);
+$stmt->execute();
+$stat['brukere'] = (int)$stmt->get_result()->fetch_assoc()['antall'];
+
+$stmt = $conn->prepare("SELECT COUNT(*) AS antall FROM anlegg WHERE borettslag_id = ?");
+$stmt->bind_param("i", $borettslag_id);
+$stmt->execute();
+$stat['anlegg'] = (int)$stmt->get_result()->fetch_assoc()['antall'];
+
+$stmt = $conn->prepare("
+    SELECT
+      COUNT(*) AS plasser_totalt,
+      SUM(status = 'ledig') AS plasser_ledig,
+      SUM(status = 'opptatt') AS plasser_opptatt
+    FROM plasser p
+    JOIN anlegg a ON p.anlegg_id = a.id
+    WHERE a.borettslag_id = ?
+");
+$stmt->bind_param("i", $borettslag_id);
+$stmt->execute();
+$plassStat = $stmt->get_result()->fetch_assoc();
+$stat['plasser_totalt'] = (int)($plassStat['plasser_totalt'] ?? 0);
+$stat['plasser_ledig'] = (int)($plassStat['plasser_ledig'] ?? 0);
+$stat['plasser_opptatt'] = (int)($plassStat['plasser_opptatt'] ?? 0);
+
+$stmt = $conn->prepare("
+    SELECT
+      COUNT(*) AS venteliste_totalt,
+      SUM(v.anlegg_id IS NULL OR v.anlegg_id = 0) AS venteliste_global,
+      SUM(v.anlegg_id IS NOT NULL AND v.anlegg_id <> 0) AS venteliste_anlegg
+    FROM venteliste v
+    WHERE v.borettslag_id = ?
+");
+$stmt->bind_param("i", $borettslag_id);
+$stmt->execute();
+$ventelisteStat = $stmt->get_result()->fetch_assoc();
+$stat['venteliste_totalt'] = (int)($ventelisteStat['venteliste_totalt'] ?? 0);
+$stat['venteliste_global'] = (int)($ventelisteStat['venteliste_global'] ?? 0);
+$stat['venteliste_anlegg'] = (int)($ventelisteStat['venteliste_anlegg'] ?? 0);
+
+$andelLedig = $stat['plasser_totalt'] > 0 ? round(($stat['plasser_ledig'] / $stat['plasser_totalt']) * 100) : 0;
+$andelOpptatt = $stat['plasser_totalt'] > 0 ? round(($stat['plasser_opptatt'] / $stat['plasser_totalt']) * 100) : 0;
+$andelGlobalKo = $stat['venteliste_totalt'] > 0 ? round(($stat['venteliste_global'] / $stat['venteliste_totalt']) * 100) : 0;
+$andelAnleggKo = $stat['venteliste_totalt'] > 0 ? round(($stat['venteliste_anlegg'] / $stat['venteliste_totalt']) * 100) : 0;
+
+ob_start();
+?>
+<h1>Dashboard</h1>
+<p>Oversikt over brukere, plasser, anlegg og kø i ditt borettslag.</p>
+
+<div class="stats-grid">
+  <article class="stat-card">
+    <h3>👥 Brukere</h3>
+    <p class="stat-number"><?= $stat['brukere'] ?></p>
+  </article>
+  <article class="stat-card">
+    <h3>🅿️ Anlegg</h3>
+    <p class="stat-number"><?= $stat['anlegg'] ?></p>
+  </article>
+  <article class="stat-card">
+    <h3>🚗 Plasser totalt</h3>
+    <p class="stat-number"><?= $stat['plasser_totalt'] ?></p>
+  </article>
+  <article class="stat-card">
+    <h3>⏳ I kø</h3>
+    <p class="stat-number"><?= $stat['venteliste_totalt'] ?></p>
+  </article>
+</div>
+
+<div class="charts-grid">
+  <article class="chart-card">
+    <h3>Plass-status</h3>
+    <p>Ledig: <?= $stat['plasser_ledig'] ?> · Opptatt: <?= $stat['plasser_opptatt'] ?></p>
+    <div class="progress">
+      <span class="segment ledig" style="width: <?= $andelLedig ?>%"></span>
+      <span class="segment opptatt" style="width: <?= $andelOpptatt ?>%"></span>
+    </div>
+    <small><?= $andelLedig ?>% ledige / <?= $andelOpptatt ?>% opptatte</small>
+  </article>
+
+  <article class="chart-card">
+    <h3>Kø-fordeling</h3>
+    <p>Første ledige: <?= $stat['venteliste_global'] ?> · Spesifikt anlegg: <?= $stat['venteliste_anlegg'] ?></p>
+    <div class="progress">
+      <span class="segment global" style="width: <?= $andelGlobalKo ?>%"></span>
+      <span class="segment anlegg" style="width: <?= $andelAnleggKo ?>%"></span>
+    </div>
+    <small><?= $andelGlobalKo ?>% første ledige / <?= $andelAnleggKo ?>% spesifikt anlegg</small>
+  </article>
+</div>
+<?php
+$content = ob_get_clean();
 include "admin_layout.php";

--- a/enkelparkering/admin/admin_venteliste.php
+++ b/enkelparkering/admin/admin_venteliste.php
@@ -20,7 +20,7 @@ if ($user['rolle'] !== 'admin') {
 
 // Hent venteliste med bruker og anlegg
 $stmt = $conn->prepare("
-    SELECT v.id, v.user_id, v.anlegg_id, v.onsker_lader, v.registrert,
+    SELECT v.id, v.user_id, v.anlegg_id, (v.onsker_lader + 0) AS onsker_lader, v.registrert,
            u.navn, u.epost, a.navn AS anlegg_navn
     FROM venteliste v
     JOIN users u ON v.user_id = u.id

--- a/enkelparkering/index.php
+++ b/enkelparkering/index.php
@@ -27,7 +27,7 @@ $har_global_venteliste = $er_på_venteliste && $venteliste_anlegg_id === 0;
 
 
 // Hent anlegg + oppsummering fra plasser
-$sql = "SELECT a.id, a.navn, a.type, a.lat, a.lng,
+$sql = "SELECT a.id, a.navn, a.type, a.lat, a.lng, a.har_ladere,
         COUNT(p.id) as total,
         SUM(p.status = 'ledig') as ledige,
         SUM(p.status = 'opptatt') as opptatte,
@@ -40,6 +40,13 @@ $stmt = $conn->prepare($sql);
 $stmt->bind_param("i", $user['borettslag_id']);
 $stmt->execute();
 $anlegg = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+$finnes_ladere_i_borettslag = false;
+foreach ($anlegg as $anleggData) {
+    if (!empty($anleggData['har_ladere'])) {
+        $finnes_ladere_i_borettslag = true;
+        break;
+    }
+}
 
 ?>
 <!DOCTYPE html>
@@ -93,20 +100,32 @@ $anlegg = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
       </div>
     <?php endif; ?>
   <!-- Global venteliste-boks -->
-    <form method="post" action="venteliste.php">
-    <input type="hidden" name="anlegg_id" value="">
-    <label>
-        <input type="checkbox" name="onsker_lader" value="1" <?= $er_på_venteliste ? 'disabled' : '' ?>>
-        Ønsker lader
-    </label>
-    <button type="submit" class="global-waitlist-button" <?= $er_på_venteliste ? 'disabled' : '' ?>>
-        <?=
-          $har_global_venteliste
-            ? '✔️ Du står på venteliste for første ledige plass i borettslaget'
-            : ($er_på_venteliste ? 'Du står på venteliste for et spesifikt anlegg' : '➕ Meld meg på venteliste for første ledige plass i borettslaget')
-        ?>
-    </button>
-    </form>
+    <div class="facility-card waitlist-hero-card">
+      <h3>⏳ Første ledige plass</h3>
+      <p>Meld deg på én samlet kø for første ledige plass i borettslaget.</p>
+      <form method="post" action="venteliste.php">
+      <input type="hidden" name="anlegg_id" value="">
+      <label>
+          <input
+            type="checkbox"
+            name="onsker_lader"
+            value="1"
+            <?= ($er_på_venteliste || !$finnes_ladere_i_borettslag) ? 'disabled' : '' ?>
+          >
+          Ønsker lader
+      </label>
+      <?php if (!$finnes_ladere_i_borettslag): ?>
+        <small>Det finnes ingen anlegg med ladere i borettslaget.</small>
+      <?php endif; ?>
+      <button type="submit" class="global-waitlist-button" <?= $er_på_venteliste ? 'disabled' : '' ?>>
+          <?=
+            $har_global_venteliste
+              ? '✔️ Du står på venteliste for første ledige plass i borettslaget'
+              : ($er_på_venteliste ? 'Du står på venteliste for et spesifikt anlegg' : '➕ Meld meg på venteliste for første ledige plass i borettslaget')
+          ?>
+      </button>
+      </form>
+    </div>
 
     <!-- Liste over anlegg -->
   <?php foreach ($anlegg as $a): ?>
@@ -122,9 +141,17 @@ $anlegg = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
       <form method="post" action="venteliste.php">
         <input type="hidden" name="anlegg_id" value="<?= $a['id'] ?>">
         <label>
-            <input type="checkbox" name="onsker_lader" value="1" <?= $er_på_venteliste ? 'disabled' : '' ?>>
+            <input
+              type="checkbox"
+              name="onsker_lader"
+              value="1"
+              <?= ($er_på_venteliste || !$a['har_ladere']) ? 'disabled' : '' ?>
+            >
             Ønsker lader
         </label>
+        <?php if (!$a['har_ladere']): ?>
+          <small>Dette anlegget har ingen ladere.</small>
+        <?php endif; ?>
         <button type="submit" <?= $er_på_venteliste ? 'disabled' : '' ?>>
             <?=
               ($er_på_venteliste && $venteliste_anlegg_id === (int)$a['id'])

--- a/enkelparkering/min_venteliste.php
+++ b/enkelparkering/min_venteliste.php
@@ -62,7 +62,7 @@ $rolle = $user['rolle'] ?? '';
 
 // Hent oppføring for brukeren
 $stmt = $conn->prepare("
-    SELECT v.id, v.anlegg_id, v.onsker_lader, v.registrert, a.navn AS anlegg_navn
+    SELECT v.id, v.anlegg_id, (v.onsker_lader + 0) AS onsker_lader, v.registrert, a.navn AS anlegg_navn
     FROM venteliste v
     LEFT JOIN anlegg a ON v.anlegg_id = a.id
     WHERE v.user_id = ? AND v.borettslag_id = ?

--- a/enkelparkering/style.css
+++ b/enkelparkering/style.css
@@ -318,6 +318,26 @@ main,
   margin-top: 0;
   color: #2c2c2c;
 }
+
+.waitlist-hero-card {
+  border: 2px solid #d7e6ff;
+}
+
+.waitlist-hero-card h3 {
+  margin-bottom: 0.4rem;
+}
+
+.waitlist-hero-card p {
+  margin-top: 0;
+}
+
+.waitlist-hero-card small {
+  display: block;
+  margin-top: -0.4rem;
+  margin-bottom: 0.7rem;
+  color: #5e6b7a;
+}
+
 button[disabled] {
   background: #d4d4d4 !important;
   cursor: not-allowed;

--- a/enkelparkering/venteliste.php
+++ b/enkelparkering/venteliste.php
@@ -9,8 +9,25 @@ if (!isset($_SESSION['user_id'])) {
 
 $user_id = $_SESSION['user_id'];
 $borettslag_id = $_SESSION['borettslag_id']; 
-$anlegg_id = !empty($_POST['anlegg_id']) ? (int)$_POST['anlegg_id'] : null;
-$onsker_lader = isset($_POST['onsker_lader']) ? 1 : 0;
+$anlegg_id = isset($_POST['anlegg_id']) && $_POST['anlegg_id'] !== '' ? (int)$_POST['anlegg_id'] : null;
+$onsker_lader = (isset($_POST['onsker_lader']) && $_POST['onsker_lader'] === '1') ? 1 : 0;
+
+if ($anlegg_id !== null) {
+    $stmt = $conn->prepare("SELECT id, har_ladere FROM anlegg WHERE id = ? AND borettslag_id = ? LIMIT 1");
+    $stmt->bind_param("ii", $anlegg_id, $borettslag_id);
+    $stmt->execute();
+    $valgt_anlegg = $stmt->get_result()->fetch_assoc();
+
+    if (!$valgt_anlegg) {
+        $_SESSION['message'] = "❌ Ugyldig anlegg valgt.";
+        header("Location: index.php");
+        exit;
+    }
+
+    if (!(int)$valgt_anlegg['har_ladere']) {
+        $onsker_lader = 0;
+    }
+}
 
 // Sjekk om bruker allerede står på ventelisten i dette borettslaget
 $stmt = $conn->prepare("SELECT id FROM venteliste WHERE user_id = ? AND borettslag_id = ?");


### PR DESCRIPTION
### Motivation
- Rettet en feil hvor "Ønsker lader" kunne bli registrert feil når brukeren meldte seg på venteliste, og unngå at lader-ønske kan hukes av for anlegg som ikke har ladere. 
- Gjort den øverste «første ledige»-knappen tydeligere med et eget kort og forklarende tekst slik at brukere forstår hva de melder seg på. 
- Ønsket også bedre oversikt for administratorer ved å vise nøkkeltall og enkle visualiseringer på Dashboard-siden. 

### Description
- Validerer og parserer `onsker_lader` robust fra POST i `enkelparkering/venteliste.php`, slår av lader-ønske når det valgte anlegget ikke har ladere, og avviser ugyldig anlegg. 
- Gjorde «første ledige»-påmelding tydeligere i `enkelparkering/index.php` ved å pakke den i et eget kort med tittel, forklaring og kondisjonelt deaktivert lader-checkbox når borettslaget/anlegget ikke har ladere. 
- Deaktiverer lader-avhuking i UI for enkeltanlegg uten ladere og viser hjelpetekst i `enkelparkering/index.php` og `enkelparkering/style.css`. 
- Sørget for korrekt tolkning av `onsker_lader` fra databasen ved å caste til numerisk verdi i `enkelparkering/admin/admin_venteliste.php` og `enkelparkering/min_venteliste.php`. 
- La til et enkelt, visuelt admin-dashboard i `enkelparkering/admin/admin.php` og styling i `enkelparkering/admin/admin.css` som viser brukere, anlegg, plasser (ledig/opptatt) og køfordeling (første ledige vs spesifikt anlegg). 

### Testing
- Kjørte syntakskontroll med `php -l` for `enkelparkering/index.php`, `enkelparkering/venteliste.php`, `enkelparkering/min_venteliste.php`, `enkelparkering/admin/admin.php` og `enkelparkering/admin/admin_venteliste.php`, og alle viste "No syntax errors detected". 
- Ingen andre automatiske tester finnes i repoet, endringene er verifisert via statisk PHP-syntaks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de967572a48327b5d2c53058aea0d1)