### PR TITLE
Forbedre Min side og gjøre adresseoppslag mer robust

### DIFF
--- a/enkelparkering/index.php
+++ b/enkelparkering/index.php
@@ -10,7 +10,9 @@ if (!isset($_SESSION['user_id'])) {
 
 // Hent brukerinfo
 $user_id = $_SESSION['user_id'];
-$sql = "SELECT * FROM users WHERE id = ?";
+$sql = "SELECT u.*, b.navn AS borettslag_navn FROM users u
+        LEFT JOIN borettslag b ON u.borettslag_id = b.id
+        WHERE u.id = ?";
 $stmt = $conn->prepare($sql);
 $stmt->bind_param("i", $user_id);
 $stmt->execute();
@@ -67,7 +69,7 @@ foreach ($anlegg as $anleggData) {
     <button class="menu-toggle" id="menuToggle">☰</button>
     <nav class="nav">
       <a href="index.php">🏠 Hjem</a>
-      <a href="min_side.php">🚗 Mine plasser</a>
+      <a href="min_side.php">👤 Min side</a>
       <a href="min_venteliste.php">📋 Min venteliste</a>
       <?php if ($user['rolle'] === 'admin'): ?>
         <a href="admin/admin.php">Adminpanel</a>
@@ -94,6 +96,7 @@ foreach ($anlegg as $anleggData) {
         <h3>📍 Nærmeste ledige plass</h3>
         <p id="nearestSpotInfo"
            data-address="<?= htmlspecialchars($user['adresse']) ?>"
+           data-borettslag="<?= htmlspecialchars($user['borettslag_navn'] ?? '') ?>"
            data-anlegg='<?= htmlspecialchars(json_encode($anlegg, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES), ENT_QUOTES, 'UTF-8') ?>'>
           Finner nærmeste ledige plass basert på adressen din…
         </p>
@@ -214,6 +217,7 @@ foreach ($anlegg as $anleggData) {
     if (!infoElement) return;
 
     var adresse = infoElement.dataset.address;
+    var borettslagNavn = (infoElement.dataset.borettslag || '').trim();
     var anleggListe = [];
     try {
       anleggListe = JSON.parse(infoElement.dataset.anlegg || '[]');
@@ -230,17 +234,17 @@ foreach ($anlegg as $anleggData) {
       return;
     }
 
-    var geoUrl = 'https://nominatim.openstreetmap.org/search?format=json&limit=1&q=' + encodeURIComponent(adresse);
-    fetch(geoUrl, { headers: { 'Accept': 'application/json' } })
-      .then(function (response) { return response.json(); })
-      .then(function (data) {
-        if (!Array.isArray(data) || !data.length) {
-          infoElement.textContent = 'Fant ikke koordinater for adressen din. Sjekk at adressen er komplett.';
+    var geoKandidater = lagAdresseKandidater(adresse, borettslagNavn);
+
+    finnKoordinater(geoKandidater)
+      .then(function (posisjon) {
+        if (!posisjon) {
+          infoElement.textContent = 'Fant ikke koordinater for adressen din. Sjekk at adressen er komplett, eller oppdater den på Min side.';
           return;
         }
 
-        var brukerLat = Number(data[0].lat);
-        var brukerLng = Number(data[0].lon);
+        var brukerLat = Number(posisjon.lat);
+        var brukerLng = Number(posisjon.lon);
         var naermest = null;
 
         kandidater.forEach(function (a) {
@@ -262,6 +266,38 @@ foreach ($anlegg as $anleggData) {
         infoElement.textContent = 'Kunne ikke beregne avstand akkurat nå. Prøv igjen senere.';
       });
   })();
+
+  function lagAdresseKandidater(adresse, borettslagNavn) {
+    var base = (adresse || '').trim();
+    if (!base) return [];
+
+    var kandidater = [base];
+    if (borettslagNavn) kandidater.push(base + ', ' + borettslagNavn);
+    kandidater.push(base + ', Oslo');
+    kandidater.push(base + ', Oslo, Norge');
+    kandidater.push(base + ', Norge');
+
+    return Array.from(new Set(kandidater.map(function (k) { return k.trim(); }).filter(Boolean)));
+  }
+
+  function finnKoordinater(kandidater) {
+    if (!kandidater.length) return Promise.resolve(null);
+
+    var query = kandidater[0];
+    var geoUrl = 'https://nominatim.openstreetmap.org/search?format=json&limit=1&countrycodes=no&q=' + encodeURIComponent(query);
+
+    return fetch(geoUrl, { headers: { 'Accept': 'application/json' } })
+      .then(function (response) { return response.json(); })
+      .then(function (data) {
+        if (Array.isArray(data) && data.length) {
+          return data[0];
+        }
+        return finnKoordinater(kandidater.slice(1));
+      })
+      .catch(function () {
+        return finnKoordinater(kandidater.slice(1));
+      });
+  }
 
   function kalkulerAvstandKm(lat1, lng1, lat2, lng2) {
     var R = 6371;

--- a/enkelparkering/min_side.php
+++ b/enkelparkering/min_side.php
@@ -9,9 +9,38 @@ if (!isset($_SESSION['user_id'])) {
 
 $user_id = $_SESSION['user_id'];
 $borettslag_id = $_SESSION['borettslag_id'];
+$message = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['oppdater_profil'])) {
+    $nyEpost = trim($_POST['epost'] ?? '');
+    $nyAdresse = trim($_POST['adresse'] ?? '');
+
+    if (!filter_var($nyEpost, FILTER_VALIDATE_EMAIL)) {
+        $message = '❌ Ugyldig e-postadresse.';
+    } elseif ($nyAdresse === '') {
+        $message = '❌ Adresse kan ikke være tom.';
+    } else {
+        $stmt = $conn->prepare("SELECT id FROM users WHERE epost = ? AND id <> ? LIMIT 1");
+        $stmt->bind_param("si", $nyEpost, $user_id);
+        $stmt->execute();
+        $epostFinnes = $stmt->get_result()->fetch_assoc();
+
+        if ($epostFinnes) {
+            $message = '❌ E-postadressen er allerede i bruk av en annen konto.';
+        } else {
+            $stmt = $conn->prepare("UPDATE users SET epost = ?, adresse = ? WHERE id = ? AND borettslag_id = ?");
+            $stmt->bind_param("ssii", $nyEpost, $nyAdresse, $user_id, $borettslag_id);
+            if ($stmt->execute()) {
+                $message = '✅ Profilen din er oppdatert.';
+            } else {
+                $message = '❌ Klarte ikke å oppdatere profilen. Prøv igjen.';
+            }
+        }
+    }
+}
 
 // Hent navn på innlogget bruker
-$stmt = $conn->prepare("SELECT navn, rolle FROM users WHERE id = ?");
+$stmt = $conn->prepare("SELECT navn, rolle, epost, adresse FROM users WHERE id = ?");
 $stmt->bind_param("i", $user_id);
 $stmt->execute();
 $user = $stmt->get_result()->fetch_assoc();
@@ -42,7 +71,7 @@ unset($plass);
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Mine plasser – Plogveien Borettslag</title>
+  <title>Min side – Plogveien Borettslag</title>
   <link rel="stylesheet" href="style.css">
   <script src="js.js" defer></script>
 </head>
@@ -52,7 +81,7 @@ unset($plass);
     <button class="menu-toggle" id="menuToggle">☰</button>
     <nav class="nav">
       <a href="index.php">🏠 Hjem</a>
-      <a href="min_side.php">🚗 Mine plasser</a>
+      <a href="min_side.php">👤 Min side</a>
       <a href="min_venteliste.php">📋 Min venteliste</a>
       <?php if ($rolle === 'admin'): ?>
         <a href="admin/admin.php">Adminpanel</a>
@@ -63,6 +92,27 @@ unset($plass);
 
   <main class="dashboard">
     <aside class="sidebar">
+      <h2>Min side</h2>
+
+      <?php if ($message): ?>
+        <p class="message"><?= htmlspecialchars($message) ?></p>
+      <?php endif; ?>
+
+      <div class="facility-card">
+        <h3>👤 Min profil</h3>
+        <p>Her kan du oppdatere e-post og adresse. Adressen brukes for å finne nærmeste ledige plass.</p>
+        <form method="post" class="profile-form">
+          <label for="epost"><strong>E-post</strong></label>
+          <input id="epost" type="email" name="epost" value="<?= htmlspecialchars($user['epost'] ?? '') ?>" required>
+
+          <label for="adresse"><strong>Adresse</strong></label>
+          <input id="adresse" type="text" name="adresse" value="<?= htmlspecialchars($user['adresse'] ?? '') ?>" required>
+
+          <small>Tips: Bruk full adresse, f.eks. «Johan Hirschs vei 15, Oslo».</small>
+          <button type="submit" name="oppdater_profil" value="1">💾 Lagre profil</button>
+        </form>
+      </div>
+
       <h2>Mine parkeringsplasser</h2>
 
       <?php if (empty($plasser)): ?>

--- a/enkelparkering/min_venteliste.php
+++ b/enkelparkering/min_venteliste.php
@@ -96,7 +96,7 @@ if ($oppføring) {
     <button class="menu-toggle" id="menuToggle">☰</button>
     <nav class="nav">
       <a href="index.php">🏠 Hjem</a>
-      <a href="min_side.php">🚗 Mine plasser</a>
+      <a href="min_side.php">👤 Min side</a>
       <a href="min_venteliste.php">📋 Min venteliste</a>
       <?php if ($rolle === 'admin'): ?>
         <a href="admin/admin.php">Adminpanel</a>
@@ -198,7 +198,7 @@ if ($oppføring) {
                   <p><a href="kontrakter/<?= rawurlencode($kontrakt['filnavn']) ?>" target="_blank">📄 Åpne kontrakt</a></p>
                 <?php endif; ?>
               <?php else: ?>
-                <p>Kontrakten er ferdigstilt. Følg med i mine plasser for oppdatert status.</p>
+                <p>Kontrakten er ferdigstilt. Følg med på Min side for oppdatert status.</p>
                 <?php if (!empty($kontrakt['filnavn'])): ?>
                   <p><a href="kontrakter/<?= rawurlencode($kontrakt['filnavn']) ?>" target="_blank">📄 Åpne kontrakt</a></p>
                 <?php endif; ?>

--- a/enkelparkering/style.css
+++ b/enkelparkering/style.css
@@ -107,6 +107,33 @@ main,
   border-top: 1px solid rgba(255, 255, 255, 0.25);
 }
 
+.profile-form label {
+  display: block;
+  margin-bottom: 0.35rem;
+  color: #2f2f2f;
+}
+
+.profile-form input[type="text"],
+.profile-form input[type="email"] {
+  width: 100%;
+  padding: 12px 18px;
+  margin-bottom: 0.9rem;
+  border: none;
+  border-radius: 16px;
+  font-size: 0.95rem;
+  color: var(--text-muted);
+  background: var(--surface);
+  box-shadow: inset 6px 6px 12px var(--shadow-dark),
+    inset -6px -6px 12px var(--shadow-light);
+  box-sizing: border-box;
+}
+
+.profile-form small {
+  display: block;
+  margin-bottom: 0.9rem;
+  color: #5e6b7a;
+}
+
 .facility-card label {
   display: flex;
   align-items: center;


### PR DESCRIPTION
### Motivation
- Brukere med korte eller ufullstendige adresser (f.eks. «Johan hirschs vei 15") fikk ingen geokoding og meldingen «Fant ikke koordinater for adressen din». 
- Målet er å gi bedre treff for eksisterende lagrede adresseverdier uten at brukeren må endre dem umiddelbart. 
- Samtidig ønskes en enkel måte for brukeren å oppdatere e-post og adresse fra en profilside som fortsatt viser tidligere «mine plasser»-informasjon.

### Description
- Forbedret geokoding i `enkelparkering/index.php` ved å prøve flere adressevarianter (inkl. borettslag, «Oslo» og «Norge») rekursivt mot Nominatim med `countrycodes=no` for høyere treff-rate. 
- Lagt til borettslagsnavn i sporen (`data-borettslag`) for å prefylle kandidatspørringer og endret feilmelding til å vise en lenke/henvisning til Min side når oppløsning mislykkes. 
- Gjort `enkelparkering/min_side.php` om til en profilside som fortsatt viser eksisterende parkeringsplasser og kontrakter, og lagt til et profilskjema for oppdatering av `epost` og `adresse` med validering og sjekk for duplikat e-post. 
- Oppdatert tekster i `min_venteliste.php`/navigasjon fra «Mine plasser» til «Min side» og lagt til nødvendige stilendringer i `enkelparkering/style.css` for profilskjemaet.

### Testing
- Kjørt PHP-syntakssjekk med `php -l enkelparkering/index.php`, `php -l enkelparkering/min_side.php` og `php -l enkelparkering/min_venteliste.php`, alle sjekker returnerte «No syntax errors detected». 
- Ingen andre automatiserte tester finnes i repoet, så endringene er verifisert ved syntakssjekk alene.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de99cfe66c8327b9526d7de1567788)