### PR TITLE
Bytt adresseoppslag til Geonorge, forbedre e-postformat og vis nærmeste el-plass

### DIFF
--- a/enkelparkering/admin/send_tilbud.php
+++ b/enkelparkering/admin/send_tilbud.php
@@ -3,6 +3,11 @@ session_start();
 include_once $_SERVER['DOCUMENT_ROOT'] . '/db.php';
 require_once __DIR__ . '/../lib/PdfGenerator.php';
 
+function kodetEmne(string $subject): string
+{
+    return '=?UTF-8?B?' . base64_encode($subject) . '?=';
+}
+
 if (!isset($_SESSION['user_id'])) {
     header('Location: ../login.php');
     exit;
@@ -132,10 +137,13 @@ if ($pdfAttachment) {
     $message .= $pdfAttachment . "\r\n";
     $message .= "--{$boundary}--";
 
-    $mail_ok = @mail($venteliste_entry['epost'], $subject, $message, $headers);
+    $mail_ok = @mail($venteliste_entry['epost'], kodetEmne($subject), $message, $headers);
 } else {
-    $headers = "From: noreply@enkelparkering.test";
-    $mail_ok = @mail($venteliste_entry['epost'], $subject, $body, $headers);
+    $headers = "From: noreply@enkelparkering.test\r\n";
+    $headers .= "MIME-Version: 1.0\r\n";
+    $headers .= "Content-Type: text/plain; charset=UTF-8\r\n";
+    $headers .= "Content-Transfer-Encoding: 8bit";
+    $mail_ok = @mail($venteliste_entry['epost'], kodetEmne($subject), $body, $headers);
 }
 
 if ($mail_ok) {

--- a/enkelparkering/admin/send_tilbud_pa_nytt.php
+++ b/enkelparkering/admin/send_tilbud_pa_nytt.php
@@ -3,6 +3,11 @@ session_start();
 include_once $_SERVER['DOCUMENT_ROOT'] . '/db.php';
 require_once __DIR__ . '/../lib/PdfGenerator.php';
 
+function kodetEmne(string $subject): string
+{
+    return '=?UTF-8?B?' . base64_encode($subject) . '?=';
+}
+
 if (!isset($_SESSION['user_id'])) {
     header('Location: ../login.php');
     exit;
@@ -114,10 +119,13 @@ if ($pdfAttachment) {
     $message .= $pdfAttachment . "\r\n";
     $message .= "--{$boundary}--";
 
-    $mail_ok = @mail($kontrakt['epost'], $subject, $message, $headers);
+    $mail_ok = @mail($kontrakt['epost'], kodetEmne($subject), $message, $headers);
 } else {
-    $headers = 'From: noreply@enkelparkering.test';
-    $mail_ok = @mail($kontrakt['epost'], $subject, $body, $headers);
+    $headers = "From: noreply@enkelparkering.test\r\n";
+    $headers .= "MIME-Version: 1.0\r\n";
+    $headers .= "Content-Type: text/plain; charset=UTF-8\r\n";
+    $headers .= "Content-Transfer-Encoding: 8bit";
+    $mail_ok = @mail($kontrakt['epost'], kodetEmne($subject), $body, $headers);
 }
 
 if ($mail_ok) {

--- a/enkelparkering/index.php
+++ b/enkelparkering/index.php
@@ -93,12 +93,12 @@ foreach ($anlegg as $anleggData) {
       <p class="message">📍 Legg til adresse når du registrerer bruker/profil for å få forslag til nærmeste ledige plass.</p>
     <?php else: ?>
       <div class="facility-card nearest-card">
-        <h3>📍 Nærmeste ledige plass</h3>
+        <h3>📍 Nærmeste ledige plasser</h3>
         <p id="nearestSpotInfo"
            data-address="<?= htmlspecialchars($user['adresse']) ?>"
            data-borettslag="<?= htmlspecialchars($user['borettslag_navn'] ?? '') ?>"
            data-anlegg='<?= htmlspecialchars(json_encode($anlegg, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES), ENT_QUOTES, 'UTF-8') ?>'>
-          Finner nærmeste ledige plass basert på adressen din…
+          Finner nærmeste ledige plass og nærmeste ledige el-plass basert på adressen din…
         </p>
       </div>
     <?php endif; ?>
@@ -246,11 +246,15 @@ foreach ($anlegg as $anleggData) {
         var brukerLat = Number(posisjon.lat);
         var brukerLng = Number(posisjon.lon);
         var naermest = null;
+        var naermestEl = null;
 
         kandidater.forEach(function (a) {
           var avstandKm = kalkulerAvstandKm(brukerLat, brukerLng, Number(a.lat), Number(a.lng));
           if (!naermest || avstandKm < naermest.avstandKm) {
             naermest = { navn: a.navn, avstandKm: avstandKm, ledige: Number(a.ledige) };
+          }
+          if (Number(a.ledige_med_lader) > 0 && (!naermestEl || avstandKm < naermestEl.avstandKm)) {
+            naermestEl = { navn: a.navn, avstandKm: avstandKm, ledigeMedLader: Number(a.ledige_med_lader) };
           }
         });
 
@@ -259,8 +263,18 @@ foreach ($anlegg as $anleggData) {
           return;
         }
 
-        infoElement.innerHTML = '<strong>' + naermest.navn + '</strong> er nærmest med ledig plass (' +
+        var html = '';
+        html += '<strong>Nærmeste ledige plass:</strong> ' + naermest.navn + ' (' +
           naermest.avstandKm.toFixed(2) + ' km unna, ' + naermest.ledige + ' ledig).';
+        html += '<br>';
+        if (naermestEl) {
+          html += '<strong>Nærmeste ledige el-plass:</strong> ' + naermestEl.navn + ' (' +
+            naermestEl.avstandKm.toFixed(2) + ' km unna, ' + naermestEl.ledigeMedLader + ' ledig med lader).';
+        } else {
+          html += '<strong>Nærmeste ledige el-plass:</strong> Ingen ledige el-plasser akkurat nå.';
+        }
+
+        infoElement.innerHTML = html;
       })
       .catch(function () {
         infoElement.textContent = 'Kunne ikke beregne avstand akkurat nå. Prøv igjen senere.';
@@ -284,13 +298,23 @@ foreach ($anlegg as $anleggData) {
     if (!kandidater.length) return Promise.resolve(null);
 
     var query = kandidater[0];
-    var geoUrl = 'https://nominatim.openstreetmap.org/search?format=json&limit=1&countrycodes=no&q=' + encodeURIComponent(query);
+    var geoUrl = 'https://ws.geonorge.no/adresser/v1/sok?sok=' + encodeURIComponent(query) +
+      '&fuzzy=true&treffPerSide=1&side=0';
 
     return fetch(geoUrl, { headers: { 'Accept': 'application/json' } })
-      .then(function (response) { return response.json(); })
+      .then(function (response) {
+        if (!response.ok) {
+          throw new Error('Geonorge-feil');
+        }
+        return response.json();
+      })
       .then(function (data) {
-        if (Array.isArray(data) && data.length) {
-          return data[0];
+        var treff = Array.isArray(data && data.adresser) ? data.adresser : [];
+        if (treff.length) {
+          var punkt = treff[0].representasjonspunkt || {};
+          if (typeof punkt.lat !== 'undefined' && typeof punkt.lon !== 'undefined') {
+            return { lat: punkt.lat, lon: punkt.lon };
+          }
         }
         return finnKoordinater(kandidater.slice(1));
       })

--- a/enkelparkering/login.php
+++ b/enkelparkering/login.php
@@ -13,6 +13,11 @@ function harKolonne(mysqli $conn, string $tabell, string $kolonne): bool
     return $stmt->get_result()->num_rows > 0;
 }
 
+function kodetEmne(string $subject): string
+{
+    return '=?UTF-8?B?' . base64_encode($subject) . '?=';
+}
+
 // Håndter innlogging
 if (isset($_POST['login'])) {
     $email = trim($_POST['email']);
@@ -67,9 +72,12 @@ if (isset($_POST['register'])) {
             $body = "Hei $navn,\n\nTakk for at du registrerte deg hos EnkelParkering. Du kan nå logge inn og administrere parkeringsplassene dine.\n\nVennlig hilsen\nEnkelParkering";
             $headers = "From: noreply@robinkopperud.no\r\n" .
                        "Reply-To: noreply@robinkopperud.no\r\n" .
+                       "MIME-Version: 1.0\r\n" .
+                       "Content-Type: text/plain; charset=UTF-8\r\n" .
+                       "Content-Transfer-Encoding: 8bit\r\n" .
                        "X-Mailer: PHP/" . phpversion();
 
-            mail($email, $subject, $body, $headers);
+            mail($email, kodetEmne($subject), $body, $headers);
 
             $message = "✅ Bruker opprettet. Logg inn nå.";
         } else {


### PR DESCRIPTION
### Motivation
- Adresseoppslaget for å finne lat/lon fungerte ikke på Nominatim og skal bruke Geonorge med fuzzy-søk for bedre treff. 
- E-postmeldingene viste uønsket formatering for norske tegn hos mottakere og trenger riktig MIME/charset. 
- Brukergrensesnittet skal vise både nærmeste ledige plass og nærmeste ledige el-plass tydelig. 

### Description
- Byttet klientside-geokoding i `enkelparkering/index.php` fra Nominatim til Geonorge adresse-API `https://ws.geonorge.no/adresser/v1/sok` og satte `fuzzy=true`, samt leser `adresser[].representasjonspunkt` for `lat`/`lon`.
- Oppdatert logikk i `enkelparkering/index.php` for å beregne og vise både den nærmeste ledige plassen og den nærmeste ledige el-plassen (eller en tydelig fallback-melding hvis ingen el-plasser er ledige).
- Forbedret e-postformat i `enkelparkering/login.php`, `enkelparkering/admin/send_tilbud.php` og `enkelparkering/admin/send_tilbud_pa_nytt.php` ved å legge til `Content-Type: text/plain; charset=UTF-8`, `Content-Transfer-Encoding: 8bit` og base64-encodet UTF-8-emne via hjelpefunksjon `kodetEmne()`.
- Mindre tekstendringer i UI (`Nærmeste ledige plasser` + beskrivende hjelpe-tekst) og tilpasset e-post-headers ved både vedlegg- og ikke-vedlegg-flyter.

### Testing
- Kjørte syntax-sjekk med `php -l` på endrede filer: `enkelparkering/index.php`, `enkelparkering/login.php`, `enkelparkering/admin/send_tilbud.php`, `enkelparkering/admin/send_tilbud_pa_nytt.php`, og alle passerte uten syntaksfeil.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de9d317778832786a856a71bef8324)