### PR TITLE
Toppnavigasjon, snitt-salg preview og sortering av ordre etter avkastning

### DIFF
--- a/crypto-tracker/assets/app.js
+++ b/crypto-tracker/assets/app.js
@@ -20,6 +20,9 @@ document.addEventListener('DOMContentLoaded', () => {
     const assetFilterSelect = document.getElementById('filter_asset');
     const statusFilterRadios = document.querySelectorAll('input[name="status"]');
     const apiDebugList = document.getElementById('apiDebugList');
+    const topNavButtons = document.querySelectorAll('.nav-btn');
+    const viewSections = document.querySelectorAll('.view-section');
+    const ordersTable = document.getElementById('ordersTable');
 
     let livePrices = {};
     let symbolPrices = {};
@@ -196,12 +199,17 @@ document.addEventListener('DOMContentLoaded', () => {
             }
 
             const key = `${assetSymbol}-${currency}`;
+            const { price: livePrice, currency: liveCurrency } = resolveLivePrice(assetSymbol, currency);
             if (!assets[key]) {
-                assets[key] = { asset: assetSymbol, currency, totalQty: 0, totalCost: 0 };
+                assets[key] = { asset: assetSymbol, currency, totalQty: 0, totalCost: 0, livePrice, liveCurrency };
             }
 
             assets[key].totalQty += remaining;
             assets[key].totalCost += remaining * entryPrice;
+            if (!Number.isFinite(assets[key].livePrice) && Number.isFinite(livePrice)) {
+                assets[key].livePrice = livePrice;
+                assets[key].liveCurrency = liveCurrency;
+            }
         });
 
         const entries = Object.values(assets).sort((a, b) => a.asset.localeCompare(b.asset));
@@ -229,7 +237,44 @@ document.addEventListener('DOMContentLoaded', () => {
                     <p class="eyebrow">Åpen mengde</p>
                     <p class="mono">${formatNumber(entry.totalQty)}</p>
                 </div>
+                <div class="preview-row">
+                    <label>Forhåndsvis salg (snitt)</label>
+                    <div class="input-with-addon">
+                        <input type="number" step="0.00000001" min="0" class="asset-preview-price-input" placeholder="${Number.isFinite(entry.livePrice) ? formatNumber(entry.livePrice) : '0'}">
+                        <span class="input-addon">${entry.currency}</span>
+                    </div>
+                    <p class="hint">Beregner fortjeneste for hele åpne mengden.</p>
+                </div>
+                <div class="preview-result">
+                    <p class="eyebrow">Estimert fortjeneste</p>
+                    <p class="mono profit asset-preview-profit">-</p>
+                </div>
             `;
+            const previewInput = card.querySelector('.asset-preview-price-input');
+            const previewProfit = card.querySelector('.asset-preview-profit');
+            const costBasis = averagePrice * entry.totalQty;
+
+            const updateAssetPreview = () => {
+                const sellPrice = parsePositiveNumber(previewInput?.value || '');
+                if (!Number.isFinite(sellPrice) || !Number.isFinite(costBasis)) {
+                    previewProfit.textContent = '-';
+                    previewProfit.classList.remove('positive', 'negative');
+                    return;
+                }
+
+                const profit = (sellPrice * entry.totalQty) - costBasis;
+                previewProfit.textContent = formatWithCurrency(profit, entry.currency);
+                previewProfit.classList.remove('positive', 'negative');
+                if (profit > 0) previewProfit.classList.add('positive');
+                if (profit < 0) previewProfit.classList.add('negative');
+            };
+
+            previewInput?.addEventListener('input', updateAssetPreview);
+
+            if (Number.isFinite(entry.livePrice)) {
+                previewInput.value = formatNumber(entry.livePrice);
+                updateAssetPreview();
+            }
             averagesContainer.appendChild(card);
         });
     }
@@ -319,6 +364,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
             if (Number.isFinite(currentPrice) && !Number.isNaN(entryPrice) && !Number.isNaN(remaining) && remaining > 0) {
                 const profitNative = remaining * (currentPrice - entryPrice);
+                const returnPercent = entryPrice > 0 ? ((currentPrice - entryPrice) / entryPrice) * 100 : Number.NEGATIVE_INFINITY;
+                card.dataset.returnPercent = Number.isFinite(returnPercent) ? String(returnPercent) : String(Number.NEGATIVE_INFINITY);
 
                 if (profitEl) {
                     profitEl.textContent = formatWithCurrency(profitNative, displayCurrency);
@@ -332,8 +379,14 @@ document.addEventListener('DOMContentLoaded', () => {
             } else if (profitEl) {
                 profitEl.textContent = '-';
                 profitEl.classList.remove('positive', 'negative');
+                card.dataset.returnPercent = String(Number.NEGATIVE_INFINITY);
             }
         });
+
+        const sortableCards = Array.from(cards).filter(card => !card.classList.contains('is-hidden'));
+        sortableCards
+            .sort((a, b) => Number.parseFloat(b.dataset.returnPercent || '-Infinity') - Number.parseFloat(a.dataset.returnPercent || '-Infinity'))
+            .forEach(card => ordersTable?.appendChild(card));
 
         if (resolutionLogs.length) {
             setApiDebugMessage('resolution', resolutionLogs.join(' · '));
@@ -443,6 +496,23 @@ document.addEventListener('DOMContentLoaded', () => {
 
     refreshButton?.addEventListener('click', fetchLivePrices);
 
+    function activateView(targetId) {
+        viewSections.forEach(section => {
+            section.classList.toggle('is-hidden', section.id !== targetId);
+        });
+        topNavButtons.forEach(button => {
+            button.classList.toggle('is-active', button.dataset.target === targetId);
+        });
+    }
+
+    topNavButtons.forEach(button => {
+        button.addEventListener('click', () => {
+            const target = button.dataset.target;
+            if (!target) return;
+            activateView(target);
+        });
+    });
+
     function hideCloseModal() {
         closeModal?.classList.remove('open');
         document.body.classList.remove('modal-open');
@@ -522,5 +592,6 @@ document.addEventListener('DOMContentLoaded', () => {
 
     applyFilters();
     fetchLivePrices();
+    activateView('portfolioSection');
     setInterval(fetchLivePrices, 60000);
 });

--- a/crypto-tracker/assets/style.css
+++ b/crypto-tracker/assets/style.css
@@ -99,6 +99,21 @@ header h1 {
     margin-top: 0;
 }
 
+.top-nav {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    position: sticky;
+    top: 8px;
+    z-index: 5;
+}
+
+.nav-btn.is-active {
+    background: var(--accent);
+    color: #0f172a;
+    border-color: var(--accent);
+}
+
 .form-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));

--- a/crypto-tracker/index.php
+++ b/crypto-tracker/index.php
@@ -126,7 +126,15 @@ if (!empty($orders)) {
         <div class="alert <?php echo h($flash['type']); ?>"><?php echo h($flash['message']); ?></div>
     <?php endif; ?>
 
-    <section class="card portfolio-header">
+    <nav class="top-nav card" aria-label="Visning">
+        <button type="button" class="btn nav-btn is-active" data-target="portfolioSection">Portefølje</button>
+        <button type="button" class="btn nav-btn" data-target="ordersSection">Ordre</button>
+        <button type="button" class="btn nav-btn" data-target="addOrderSection">Legg inn ordre</button>
+        <button type="button" class="btn nav-btn" data-target="filtersSection">Filtre</button>
+        <button type="button" class="btn nav-btn" data-target="averagesSection">Gjennomsnitt</button>
+    </nav>
+
+    <section class="card portfolio-header view-section" id="portfolioSection">
         <div>
             <h2>Portefølje i NOK</h2>
             <p class="hint">Beregnet fra filtrerte ordrer (valuta konvertert til NOK).</p>
@@ -151,7 +159,7 @@ if (!empty($orders)) {
         </div>
     </section>
 
-    <section class="card">
+    <section class="card view-section is-hidden" id="addOrderSection">
         <h2>Add a new BUY order</h2>
         <form method="POST" action="actions.php" class="form-grid">
             <input type="hidden" name="action" value="create_order">
@@ -191,7 +199,7 @@ if (!empty($orders)) {
         </form>
     </section>
 
-    <section class="card filters">
+    <section class="card filters view-section is-hidden" id="filtersSection">
         <form method="GET" class="filter-row">
             <div class="form-control">
                 <label for="filter_asset">Filter asset</label>
@@ -215,7 +223,7 @@ if (!empty($orders)) {
         </form>
     </section>
 
-    <section class="card">
+    <section class="card view-section is-hidden" id="ordersSection">
         <div class="price-row">
             <div>
                 <h2>Orders with live prices</h2>
@@ -315,7 +323,7 @@ if (!empty($orders)) {
         </div>
     </section>
 
-    <section class="card">
+    <section class="card view-section is-hidden" id="averagesSection">
         <div class="price-row">
             <div>
                 <h2>Gjennomsnittspris per asset</h2>


### PR DESCRIPTION
### Motivation
- Gjøre det enklere å bytte mellom ulike visninger uten å navigere til nye sider, og legge til en rask forhåndsvisning for å se estimert gevinst når man selger hele åpne mengden per asset.

### Description
- La til en sticky toppnavigasjon i `crypto-tracker/index.php` med knapper som bytter mellom visninger ved å vise/skjule seksjoner (`.nav-btn`, `.view-section`, `#portfolioSection`, `#ordersSection`, `#addOrderSection`, `#filtersSection`, `#averagesSection`).
- Implementerte view-switching og aktiv knapp-logikk i `crypto-tracker/assets/app.js` samt initial visning = `portfolioSection`.
- La til forhåndsvisning for salg i gjennomsnittsdelen ved å bygge snittkort med inputfelt (`.asset-preview-price-input`) og beregnet estimert fortjeneste (`.asset-preview-profit`) i `crypto-tracker/assets/app.js`.
- Endret ordreoppdatering i `crypto-tracker/assets/app.js` til å beregne avkastning (prosent) per synlig ordre og sortere synlige ordrekort i `#ordersTable` fra høyest til lavest avkastning.
- Oppdatert `crypto-tracker/assets/style.css` med styling for `.top-nav` og aktiv knapp (`.nav-btn.is-active`).

### Testing
- Kjørte `php -l crypto-tracker/index.php` for syntakskontroll av PHP-filen og fikk ingen syntax errors (OK).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4f3a5cbcc83279ad29542d6f7539b)