### PR TITLE
Forenkle boligavkastning: fjern utleie og legg til felleskostnader

### DIFF
--- a/boligavkastning/index.html
+++ b/boligavkastning/index.html
@@ -3,14 +3,14 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Boligavkastning – analyse av bolig og egenkapital</title>
+  <title>Boligavkastning – fortjeneste over tid</title>
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
   <main class="app">
     <header>
       <h1>Boligavkastning</h1>
-      <p>Se både avkastning på bolig og avkastning på egenkapital — uten database, alt beregnes i nettleseren.</p>
+      <p>Fokus på fortjeneste over valgt antall år – med finansiering, felleskostnader og salg.</p>
     </header>
 
     <section class="card">
@@ -38,22 +38,13 @@
     </section>
 
     <section class="card">
-      <h2>2) Drift og leie</h2>
+      <h2>2) Løpende kostnader</h2>
       <div class="grid">
-        <label>Månedlig leieinntekt (kr)
-          <input type="number" id="monthlyRent" value="18000" min="0" step="500">
+        <label>Felleskostnader per måned (kr)
+          <input type="number" id="monthlyCommonCosts" value="4500" min="0" step="100">
         </label>
-        <label>Ledighet (%)
-          <input type="number" id="vacancyPct" value="4" min="0" max="100" step="0.1">
-        </label>
-        <label>Driftskostnader per år (kr)
-          <input type="number" id="opexYear" value="45000" min="0" step="1000">
-        </label>
-        <label>Vedlikehold per år (kr)
-          <input type="number" id="maintYear" value="25000" min="0" step="1000">
-        </label>
-        <label>Leievekst per år (%)
-          <input type="number" id="rentGrowthPct" value="2.5" min="-10" max="20" step="0.1">
+        <label>Andre kostnader per år (kr)
+          <input type="number" id="otherCostsYear" value="20000" min="0" step="1000">
         </label>
         <label>Kostnadsvekst per år (%)
           <input type="number" id="costGrowthPct" value="2.0" min="-10" max="20" step="0.1">
@@ -74,25 +65,25 @@
     </section>
 
     <section class="card actions">
-      <button id="calculateBtn">Beregn avkastning</button>
-      <p class="note">Tips: Endre én variabel om gangen for å gjøre enkel sensitivitetsanalyse.</p>
+      <button id="calculateBtn">Beregn fortjeneste</button>
+      <p class="note">Tips: Test ulike kombinasjoner av tidshorisont, rente og salgspris.</p>
     </section>
 
     <section class="results">
       <article class="metric">
-        <h3>Boligens totalavkastning</h3>
+        <h3>Total fortjeneste på bolig</h3>
         <p id="propertyTotal" class="value">-</p>
         <small id="propertyCagr">-</small>
       </article>
       <article class="metric highlight">
-        <h3>Egenkapitalavkastning</h3>
+        <h3>Fortjeneste på egenkapital</h3>
         <p id="equityTotal" class="value">-</p>
         <small id="equityCagr">-</small>
       </article>
       <article class="metric">
-        <h3>Årlig netto kontantstrøm</h3>
-        <p id="netCashFlow" class="value">-</p>
-        <small>Snitt per år etter renter/avdrag/kostnader</small>
+        <h3>Snitt årlig kostnad</h3>
+        <p id="avgAnnualCost" class="value">-</p>
+        <small>Felleskostnader + øvrige kostnader + renter/avdrag</small>
       </article>
       <article class="metric">
         <h3>Lånesaldo ved salg</h3>
@@ -104,16 +95,6 @@
     <section class="card" id="detailsCard">
       <h2>Detaljer</h2>
       <div id="details"></div>
-    </section>
-
-    <section class="card tips">
-      <h2>Ekstra funksjonalitet du kan vurdere</h2>
-      <ul>
-        <li>Sensitivitetsmatrise (f.eks. rente × salgspris) med fargekart.</li>
-        <li>Skattemodell (utleieskatt, fradrag, gevinstbeskatning) som valgfritt lag.</li>
-        <li>Sammenligning av flere scenarier side om side (Base, Optimistisk, Stress).</li>
-        <li>Eksport til PDF/CSV for deling med bank eller medinvestorer.</li>
-      </ul>
     </section>
   </main>
 

--- a/boligavkastning/script.js
+++ b/boligavkastning/script.js
@@ -1,7 +1,6 @@
 const ids = [
   'purchasePrice', 'equity', 'buyCostPct', 'interestRate', 'loanYears', 'holdYears',
-  'monthlyRent', 'vacancyPct', 'opexYear', 'maintYear', 'rentGrowthPct', 'costGrowthPct',
-  'salePrice', 'sellCostPct'
+  'monthlyCommonCosts', 'otherCostsYear', 'costGrowthPct', 'salePrice', 'sellCostPct'
 ];
 
 const fmtNok = (n) => new Intl.NumberFormat('nb-NO', { style: 'currency', currency: 'NOK', maximumFractionDigits: 0 }).format(n);
@@ -39,11 +38,8 @@ function calculate() {
   const interestRate = val('interestRate');
   const loanYears = val('loanYears');
   const holdYears = val('holdYears');
-  const monthlyRent = val('monthlyRent');
-  const vacancyPct = val('vacancyPct');
-  const opexYear = val('opexYear');
-  const maintYear = val('maintYear');
-  const rentGrowthPct = val('rentGrowthPct');
+  const monthlyCommonCosts = val('monthlyCommonCosts');
+  const otherCostsYear = val('otherCostsYear');
   const costGrowthPct = val('costGrowthPct');
   const salePrice = val('salePrice');
   const sellCostPct = val('sellCostPct');
@@ -54,15 +50,12 @@ function calculate() {
   const monthlyDebtService = annuityPayment(loanAmount, interestRate, loanYears);
   const yearlyDebtService = monthlyDebtService * 12;
 
-  let totalNetCashFlow = 0;
+  let totalOwnerCosts = 0;
   for (let year = 0; year < holdYears; year += 1) {
-    const rentFactor = Math.pow(1 + rentGrowthPct / 100, year);
     const costFactor = Math.pow(1 + costGrowthPct / 100, year);
-    const grossRentYear = monthlyRent * 12 * rentFactor;
-    const effectiveRentYear = grossRentYear * (1 - vacancyPct / 100);
-    const costsYear = (opexYear + maintYear) * costFactor;
-    const netYear = effectiveRentYear - costsYear - yearlyDebtService;
-    totalNetCashFlow += netYear;
+    const commonCostsYear = monthlyCommonCosts * 12 * costFactor;
+    const otherYear = otherCostsYear * costFactor;
+    totalOwnerCosts += commonCostsYear + otherYear + yearlyDebtService;
   }
 
   const monthsHeld = holdYears * 12;
@@ -70,15 +63,17 @@ function calculate() {
   const saleCosts = salePrice * (sellCostPct / 100);
   const equityFromSale = salePrice - saleCosts - loanBalanceAtSale;
 
-  const totalPropertyProfit = (salePrice - saleCosts) - (purchasePrice + buyCosts) + totalNetCashFlow;
-  const propertyTotalReturnPct = purchasePrice > 0 ? (totalPropertyProfit / (purchasePrice + buyCosts)) * 100 : 0;
+  const totalPropertyProfit = (salePrice - saleCosts) - (purchasePrice + buyCosts) - totalOwnerCosts;
+  const propertyTotalReturnPct = (purchasePrice + buyCosts) > 0
+    ? (totalPropertyProfit / (purchasePrice + buyCosts)) * 100
+    : 0;
 
-  const totalEquityProfit = equityFromSale + totalNetCashFlow - investedCapital;
+  const totalEquityProfit = equityFromSale - investedCapital - totalOwnerCosts;
   const equityTotalReturnPct = investedCapital > 0 ? (totalEquityProfit / investedCapital) * 100 : 0;
 
   const propertyCagr = holdYears > 0 ? (Math.pow((1 + propertyTotalReturnPct / 100), (1 / holdYears)) - 1) * 100 : 0;
   const equityCagr = holdYears > 0 ? (Math.pow((1 + equityTotalReturnPct / 100), (1 / holdYears)) - 1) * 100 : 0;
-  const avgNetCashFlow = holdYears > 0 ? totalNetCashFlow / holdYears : 0;
+  const avgAnnualCost = holdYears > 0 ? totalOwnerCosts / holdYears : 0;
 
   document.getElementById('propertyTotal').textContent = fmtPct(propertyTotalReturnPct);
   document.getElementById('propertyCagr').textContent = `Årlig snitt (CAGR): ${fmtPct(propertyCagr)}`;
@@ -86,7 +81,7 @@ function calculate() {
   document.getElementById('equityTotal').textContent = fmtPct(equityTotalReturnPct);
   document.getElementById('equityCagr').textContent = `Årlig snitt (CAGR): ${fmtPct(equityCagr)}`;
 
-  document.getElementById('netCashFlow').textContent = fmtNok(avgNetCashFlow);
+  document.getElementById('avgAnnualCost').textContent = fmtNok(avgAnnualCost);
   document.getElementById('loanBalance').textContent = fmtNok(loanBalanceAtSale);
   document.getElementById('equityFromSale').textContent = `Egenkapital frigjort ved salg: ${fmtNok(equityFromSale)}`;
 
@@ -94,9 +89,9 @@ function calculate() {
   const detailRows = [
     ['Lånebeløp ved kjøp', fmtNok(loanAmount)],
     ['Månedlig terminbeløp', fmtNok(monthlyDebtService)],
-    ['Totalt netto kontantstrøm', fmtNok(totalNetCashFlow)],
-    ['Samlet gevinst på bolig', fmtNok(totalPropertyProfit)],
-    ['Samlet gevinst på egenkapital', fmtNok(totalEquityProfit)],
+    ['Totale eierkostnader i perioden', fmtNok(totalOwnerCosts)],
+    ['Samlet fortjeneste på bolig', fmtNok(totalPropertyProfit)],
+    ['Samlet fortjeneste på egenkapital', fmtNok(totalEquityProfit)],
     ['Belåningsmultiplikator', `${leverage.toFixed(2)}x`],
     ['Netto salg etter kostnader', fmtNok(salePrice - saleCosts)],
     ['Total investert kapital', fmtNok(investedCapital)]


### PR DESCRIPTION
### Motivation
- Fjerne utleie-spesifikk funksjonalitet (leieinntekt, ledighet, leievekst) for å gjøre kalkulatoren rettet mot beregning av fortjeneste over valgt periode.
- Legge til støtte for felleskostnader og øvrige eierkostnader slik at totalkostnad og fortjeneste kan vurderes uten utleielogikk.

### Description
- Oppdatert `boligavkastning/index.html` for å fjerne utleiefelt og erstatte dem med input for `monthlyCommonCosts`, `otherCostsYear` og `costGrowthPct`, og justert UI-tekst og resultattitler.
- Endret `boligavkastning/script.js` for å fjerne alle referanser til leievariabler og i stedet akkumulere `totalOwnerCosts` (felleskostnader + øvrige kostnader + renter/avdrag) over perioden.
- Regnestykket for total fortjeneste og egenkapitalfortjeneste er oppdatert til å trekke fra eierkostnader i stedet for å bruke netto leieinntekt, og visningen oppdateres med `avgAnnualCost`, `Samlet fortjeneste på bolig` og relaterte detaljer.
- Fjernet tips/ekstra-seksjon som ikke var relevant for nye, forenklede fokus.

### Testing
- Kodesøk for utleierelaterte felt med `rg -n "monthlyRent|vacancyPct|rentGrowthPct|netCashFlow|Drift og leie|utleie" boligavkastning` returnerte ingen treff, bekrefter fjerning av utleiekode.
- JavaScript-syntakssjekk med `node --check boligavkastning/script.js` ble kjørt og bestod uten feil.
- Ingen UI-automatiserte tester ble kjørt i dette miljøet (manuell/verifisering i nettleser anbefales etter deploy).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef53d282b48327a5107d0c1abd2110)