### PR TITLE
Add personal asset tracker (Mine verdier)

### DIFF
--- a/eiendeler/actions.php
+++ b/eiendeler/actions.php
@@ -1,0 +1,89 @@
+<?php
+session_start();
+include_once $_SERVER['DOCUMENT_ROOT'] . '/db.php';
+require_once __DIR__ . '/auth.php';
+
+ensure_logged_in();
+$userId = (int)($_SESSION['user_id'] ?? 0);
+
+function redirect_with_flash(string $type, string $message): void
+{
+    $_SESSION['flash'] = ['type' => $type, 'message' => $message];
+    header('Location: index.php');
+    exit;
+}
+
+function clean_currency(string $currency): string
+{
+    $cleaned = strtoupper(trim($currency));
+    $cleaned = preg_replace('/[^A-Z]/', '', $cleaned);
+    return $cleaned !== '' ? substr($cleaned, 0, 10) : 'NOK';
+}
+
+function clean_category(string $category): string
+{
+    return in_array($category, ['property', 'crypto', 'cash', 'other'], true) ? $category : 'other';
+}
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    redirect_with_flash('error', 'Ugyldig forespørsel.');
+}
+
+$action = $_POST['action'] ?? '';
+
+if ($action === 'save_asset') {
+    $assetId = (int)($_POST['asset_id'] ?? 0);
+    $category = clean_category($_POST['category'] ?? 'other');
+    $name = trim($_POST['name'] ?? '');
+    $provider = trim($_POST['provider'] ?? '');
+    $grossValue = $_POST['gross_value'] ?? '';
+    $ownershipPercent = $_POST['ownership_percent'] ?? '100';
+    $currency = clean_currency($_POST['currency'] ?? 'NOK');
+    $valuationDate = trim($_POST['valuation_date'] ?? '');
+    $notes = trim($_POST['notes'] ?? '');
+
+    if ($name === '' || !is_numeric($grossValue) || (float)$grossValue < 0 || !is_numeric($ownershipPercent)) {
+        redirect_with_flash('error', 'Fyll ut navn, verdi og eierandel med gyldige tall.');
+    }
+
+    $grossValue = (float)$grossValue;
+    $ownershipPercent = max(0, min(100, (float)$ownershipPercent));
+    $provider = $provider !== '' ? $provider : null;
+    $notes = $notes !== '' ? $notes : null;
+    $valuationDate = $valuationDate !== '' ? $valuationDate : null;
+
+    if ($assetId > 0) {
+        $stmt = $conn->prepare('UPDATE assets SET category = ?, name = ?, provider = ?, gross_value = ?, ownership_percent = ?, currency = ?, valuation_date = ?, notes = ? WHERE id = ? AND user_id = ?');
+        if (!$stmt) {
+            redirect_with_flash('error', 'Kunne ikke forberede oppdatering.');
+        }
+        $stmt->bind_param('sssddsssii', $category, $name, $provider, $grossValue, $ownershipPercent, $currency, $valuationDate, $notes, $assetId, $userId);
+        $ok = $stmt->execute();
+    } else {
+        $stmt = $conn->prepare('INSERT INTO assets (user_id, category, name, provider, gross_value, ownership_percent, currency, valuation_date, notes) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)');
+        if (!$stmt) {
+            redirect_with_flash('error', 'Kunne ikke forberede lagring.');
+        }
+        $stmt->bind_param('isssddsss', $userId, $category, $name, $provider, $grossValue, $ownershipPercent, $currency, $valuationDate, $notes);
+        $ok = $stmt->execute();
+    }
+
+    redirect_with_flash($ok ? 'success' : 'error', $ok ? 'Eiendelen ble lagret.' : 'Kunne ikke lagre eiendelen.');
+}
+
+if ($action === 'delete_asset') {
+    $assetId = (int)($_POST['asset_id'] ?? 0);
+    if ($assetId <= 0) {
+        redirect_with_flash('error', 'Ugyldig eiendel.');
+    }
+
+    $stmt = $conn->prepare('DELETE FROM assets WHERE id = ? AND user_id = ?');
+    if (!$stmt) {
+        redirect_with_flash('error', 'Kunne ikke forberede sletting.');
+    }
+    $stmt->bind_param('ii', $assetId, $userId);
+    $stmt->execute();
+    redirect_with_flash($stmt->affected_rows > 0 ? 'success' : 'error', $stmt->affected_rows > 0 ? 'Eiendelen ble slettet.' : 'Fant ikke eiendelen.');
+}
+
+redirect_with_flash('error', 'Ukjent handling.');

--- a/eiendeler/assets/style.css
+++ b/eiendeler/assets/style.css
@@ -1,0 +1,77 @@
+:root {
+    color-scheme: light;
+    --bg: #eef4ff;
+    --card: #ffffff;
+    --ink: #0f172a;
+    --muted: #64748b;
+    --line: #dbe4f0;
+    --primary: #2563eb;
+    --primary-dark: #1d4ed8;
+    --danger: #b91c1c;
+    --success: #047857;
+}
+
+* { box-sizing: border-box; }
+body {
+    margin: 0;
+    font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    background: radial-gradient(circle at top left, #dbeafe, var(--bg) 38%, #f8fafc);
+    color: var(--ink);
+    min-height: 100vh;
+}
+
+.shell { width: min(1180px, calc(100% - 32px)); margin: 0 auto; padding: 40px 0; }
+.auth-shell { display: grid; min-height: 100vh; place-items: center; }
+.card { background: rgba(255,255,255,0.92); border: 1px solid var(--line); border-radius: 24px; box-shadow: 0 24px 70px rgba(15, 23, 42, 0.10); padding: 24px; }
+.hero { display: flex; justify-content: space-between; gap: 24px; align-items: flex-start; margin-bottom: 24px; }
+h1, h2, h3, p { margin-top: 0; }
+h1 { font-size: clamp(34px, 5vw, 58px); margin-bottom: 12px; }
+h2 { margin-bottom: 18px; }
+.hero p { color: var(--muted); max-width: 660px; line-height: 1.6; }
+.eyebrow { color: var(--primary); font-size: 0.78rem; font-weight: 800; letter-spacing: 0.12em; text-transform: uppercase; }
+.user-box { display: grid; gap: 8px; justify-items: end; color: var(--muted); }
+a { color: var(--primary); font-weight: 700; text-decoration: none; }
+.alert { border-radius: 16px; margin-bottom: 20px; padding: 14px 16px; font-weight: 700; }
+.alert.success { background: #dcfce7; color: var(--success); }
+.alert.error { background: #fee2e2; color: var(--danger); }
+.summary-grid { display: grid; grid-template-columns: 1.6fr repeat(4, 1fr); gap: 16px; margin-bottom: 16px; }
+.total-card strong { display: block; font-size: clamp(32px, 4vw, 48px); margin-bottom: 8px; }
+.total-card span, .stat-card p, .muted { color: var(--muted); }
+.stat-card strong { font-size: 22px; }
+.content-grid { display: grid; grid-template-columns: minmax(320px, 0.9fr) minmax(0, 1.4fr); gap: 16px; align-items: start; }
+.asset-form, .stacked-form { display: grid; gap: 14px; }
+label { display: grid; gap: 7px; color: #334155; font-weight: 700; }
+input, select, textarea { width: 100%; border: 1px solid #cbd5e1; border-radius: 14px; padding: 12px 14px; font: inherit; color: var(--ink); background: #fff; }
+textarea { resize: vertical; }
+.split { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+.btn { border: 0; border-radius: 999px; padding: 12px 18px; cursor: pointer; font-weight: 800; display: inline-flex; justify-content: center; }
+.btn.primary { background: var(--primary); color: #fff; }
+.btn.primary:hover { background: var(--primary-dark); }
+.btn.ghost { border: 1px solid var(--line); color: var(--ink); }
+.actions-row { display: flex; gap: 10px; align-items: center; }
+.asset-list { display: grid; gap: 12px; }
+.asset-row { display: grid; grid-template-columns: 1fr auto; gap: 18px; border: 1px solid var(--line); border-radius: 18px; padding: 18px; background: #f8fafc; }
+.asset-row h3 { margin: 8px 0 6px; }
+.asset-row p { color: var(--muted); margin-bottom: 0; }
+.notes { margin-top: 8px; color: #475569 !important; }
+.pill { display: inline-flex; border-radius: 999px; background: #dbeafe; color: #1e40af; font-size: 12px; font-weight: 800; padding: 6px 10px; }
+.value-box { text-align: right; display: grid; align-content: start; gap: 6px; }
+.value-box strong { font-size: 24px; }
+.value-box span { color: var(--muted); }
+.row-actions { display: flex; justify-content: flex-end; gap: 12px; align-items: center; }
+.row-actions form { margin: 0; }
+.row-actions button { border: 0; background: transparent; color: var(--danger); cursor: pointer; font: inherit; font-weight: 700; padding: 0; }
+.empty { color: var(--muted); }
+.auth-card { width: min(440px, 100%); }
+
+@media (max-width: 900px) {
+    .hero, .asset-row { grid-template-columns: 1fr; display: grid; }
+    .user-box, .value-box { justify-items: start; text-align: left; }
+    .summary-grid, .content-grid { grid-template-columns: 1fr; }
+}
+
+@media (max-width: 560px) {
+    .split { grid-template-columns: 1fr; }
+    .shell { width: min(100% - 20px, 1180px); padding: 20px 0; }
+    .card { padding: 18px; border-radius: 18px; }
+}

--- a/eiendeler/auth.php
+++ b/eiendeler/auth.php
@@ -1,0 +1,59 @@
+<?php
+// Shared authentication helpers for the crypto tracker.
+session_start();
+
+function ensure_logged_in(): void
+{
+    if (!isset($_SESSION['user_id'])) {
+        header('Location: login.php');
+        exit;
+    }
+}
+
+function fetch_current_user(mysqli $conn): ?array
+{
+    if (!isset($_SESSION['user_id'])) {
+        return null;
+    }
+
+    $stmt = $conn->prepare('SELECT * FROM users WHERE id = ? LIMIT 1');
+    if (!$stmt) {
+        return null;
+    }
+
+    $stmt->bind_param('i', $_SESSION['user_id']);
+    $stmt->execute();
+    $result = $stmt->get_result();
+    return $result ? $result->fetch_assoc() : null;
+}
+
+function attempt_login(mysqli $conn, string $email, string $password): bool
+{
+    $sql = 'SELECT * FROM users WHERE epost = ?';
+    $stmt = $conn->prepare($sql);
+    if (!$stmt) {
+        return false;
+    }
+
+    $stmt->bind_param('s', $email);
+    $stmt->execute();
+    $result = $stmt->get_result();
+    $user = $result ? $result->fetch_assoc() : null;
+
+    if ($user && password_verify($password, $user['passord'])) {
+        $_SESSION['user_id'] = $user['id'];
+        $_SESSION['rolle'] = $user['rolle'] ?? null;
+        $_SESSION['borettslag_id'] = $user['borettslag_id'] ?? null;
+        return true;
+    }
+
+    return false;
+}
+
+function logout_and_redirect(): void
+{
+    session_destroy();
+    header('Location: login.php');
+    exit;
+}
+?>

--- a/eiendeler/index.php
+++ b/eiendeler/index.php
@@ -1,0 +1,176 @@
+<?php
+session_start();
+include_once $_SERVER['DOCUMENT_ROOT'] . '/db.php';
+require_once __DIR__ . '/auth.php';
+
+ensure_logged_in();
+$currentUser = fetch_current_user($conn);
+$userId = (int)($_SESSION['user_id'] ?? 0);
+
+function h($value): string
+{
+    return htmlspecialchars((string)$value, ENT_QUOTES, 'UTF-8');
+}
+
+function nok($value): string
+{
+    return number_format((float)$value, 0, ',', ' ') . ' kr';
+}
+
+$categoryLabels = [
+    'property' => 'Bolig og eiendom',
+    'crypto' => 'Krypto',
+    'cash' => 'Cash og bank',
+    'other' => 'Annet',
+];
+
+$flash = $_SESSION['flash'] ?? null;
+unset($_SESSION['flash']);
+
+$stmt = $conn->prepare('SELECT * FROM assets WHERE user_id = ? ORDER BY category, updated_at DESC');
+$assets = [];
+if ($stmt) {
+    $stmt->bind_param('i', $userId);
+    $stmt->execute();
+    $result = $stmt->get_result();
+    $assets = $result ? $result->fetch_all(MYSQLI_ASSOC) : [];
+}
+
+$total = 0;
+$categoryTotals = array_fill_keys(array_keys($categoryLabels), 0);
+foreach ($assets as $asset) {
+    $netValue = (float)$asset['gross_value'] * ((float)$asset['ownership_percent'] / 100);
+    $total += $netValue;
+    $categoryTotals[$asset['category']] = ($categoryTotals[$asset['category']] ?? 0) + $netValue;
+}
+
+$editId = (int)($_GET['edit'] ?? 0);
+$editing = null;
+foreach ($assets as $asset) {
+    if ((int)$asset['id'] === $editId) {
+        $editing = $asset;
+        break;
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="no">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Mine verdier</title>
+    <link rel="stylesheet" href="assets/style.css">
+</head>
+<body>
+<main class="shell">
+    <header class="hero">
+        <div>
+            <p class="eyebrow">Personlig eiendelsoversikt</p>
+            <h1>Mine verdier</h1>
+            <p>Registrer bolig, krypto, cash og andre eiendeler med verdi, leverandør og eierandel.</p>
+        </div>
+        <div class="user-box">
+            <span>Innlogget som <strong><?php echo h($currentUser['navn'] ?? $currentUser['epost'] ?? 'bruker'); ?></strong></span>
+            <a href="logout.php">Logg ut</a>
+        </div>
+    </header>
+
+    <?php if ($flash): ?>
+        <div class="alert <?php echo h($flash['type']); ?>"><?php echo h($flash['message']); ?></div>
+    <?php endif; ?>
+
+    <section class="summary-grid" aria-label="Oppsummering">
+        <article class="card total-card">
+            <p class="eyebrow">Total nettoverdi</p>
+            <strong><?php echo h(nok($total)); ?></strong>
+            <span>Basert på verdi × eierandel.</span>
+        </article>
+        <?php foreach ($categoryLabels as $key => $label): ?>
+            <article class="card stat-card">
+                <p><?php echo h($label); ?></p>
+                <strong><?php echo h(nok($categoryTotals[$key] ?? 0)); ?></strong>
+            </article>
+        <?php endforeach; ?>
+    </section>
+
+    <section class="content-grid">
+        <article class="card">
+            <h2><?php echo $editing ? 'Endre eiendel' : 'Legg til eiendel'; ?></h2>
+            <form method="POST" action="actions.php" class="asset-form">
+                <input type="hidden" name="action" value="save_asset">
+                <input type="hidden" name="asset_id" value="<?php echo h($editing['id'] ?? '0'); ?>">
+                <label>Type
+                    <select name="category" required>
+                        <?php foreach ($categoryLabels as $key => $label): ?>
+                            <option value="<?php echo h($key); ?>" <?php echo ($editing['category'] ?? '') === $key ? 'selected' : ''; ?>><?php echo h($label); ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                </label>
+                <label>Navn
+                    <input type="text" name="name" value="<?php echo h($editing['name'] ?? ''); ?>" placeholder="F.eks. Leilighet, BTC, DNB brukskonto" required>
+                </label>
+                <label>Leverandør / lokasjon
+                    <input type="text" name="provider" value="<?php echo h($editing['provider'] ?? ''); ?>" placeholder="F.eks. bank, børs eller adresse">
+                </label>
+                <div class="split">
+                    <label>Verdi
+                        <input type="number" step="0.01" min="0" name="gross_value" value="<?php echo h($editing['gross_value'] ?? ''); ?>" required>
+                    </label>
+                    <label>Valuta
+                        <input type="text" name="currency" maxlength="10" value="<?php echo h($editing['currency'] ?? 'NOK'); ?>" required>
+                    </label>
+                </div>
+                <div class="split">
+                    <label>Eierandel %
+                        <input type="number" step="0.01" min="0" max="100" name="ownership_percent" value="<?php echo h($editing['ownership_percent'] ?? '100'); ?>" required>
+                    </label>
+                    <label>Verdidato
+                        <input type="date" name="valuation_date" value="<?php echo h($editing['valuation_date'] ?? date('Y-m-d')); ?>">
+                    </label>
+                </div>
+                <label>Notater
+                    <textarea name="notes" rows="3" placeholder="Valgfritt"><?php echo h($editing['notes'] ?? ''); ?></textarea>
+                </label>
+                <div class="actions-row">
+                    <button type="submit" class="btn primary">Lagre</button>
+                    <?php if ($editing): ?><a class="btn ghost" href="index.php">Avbryt</a><?php endif; ?>
+                </div>
+            </form>
+        </article>
+
+        <article class="card list-card">
+            <h2>Registrerte eiendeler</h2>
+            <?php if (empty($assets)): ?>
+                <p class="empty">Ingen eiendeler er registrert ennå.</p>
+            <?php else: ?>
+                <div class="asset-list">
+                    <?php foreach ($assets as $asset): ?>
+                        <?php $netValue = (float)$asset['gross_value'] * ((float)$asset['ownership_percent'] / 100); ?>
+                        <section class="asset-row">
+                            <div>
+                                <span class="pill"><?php echo h($categoryLabels[$asset['category']] ?? 'Annet'); ?></span>
+                                <h3><?php echo h($asset['name']); ?></h3>
+                                <p><?php echo h($asset['provider'] ?: 'Ingen leverandør'); ?> · <?php echo h($asset['ownership_percent']); ?> % eid</p>
+                                <?php if (!empty($asset['notes'])): ?><p class="notes"><?php echo h($asset['notes']); ?></p><?php endif; ?>
+                            </div>
+                            <div class="value-box">
+                                <strong><?php echo h(nok($netValue)); ?></strong>
+                                <span>Brutto <?php echo h(number_format((float)$asset['gross_value'], 2, ',', ' ') . ' ' . $asset['currency']); ?></span>
+                                <div class="row-actions">
+                                    <a href="?edit=<?php echo (int)$asset['id']; ?>">Endre</a>
+                                    <form method="POST" action="actions.php" onsubmit="return confirm('Slette denne eiendelen?');">
+                                        <input type="hidden" name="action" value="delete_asset">
+                                        <input type="hidden" name="asset_id" value="<?php echo (int)$asset['id']; ?>">
+                                        <button type="submit">Slett</button>
+                                    </form>
+                                </div>
+                            </div>
+                        </section>
+                    <?php endforeach; ?>
+                </div>
+            <?php endif; ?>
+        </article>
+    </section>
+</main>
+</body>
+</html>

--- a/eiendeler/login.php
+++ b/eiendeler/login.php
@@ -1,0 +1,56 @@
+<?php
+session_start();
+include_once $_SERVER['DOCUMENT_ROOT'] . '/db.php';
+require_once __DIR__ . '/auth.php';
+
+$error = '';
+
+if (isset($_SESSION['user_id'])) {
+    header('Location: index.php');
+    exit;
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $email = trim($_POST['email'] ?? '');
+    $password = trim($_POST['password'] ?? '');
+
+    if ($email === '' || $password === '') {
+        $error = 'Skriv inn e-post og passord.';
+    } elseif (attempt_login($conn, $email, $password)) {
+        header('Location: index.php');
+        exit;
+    } else {
+        $error = 'Ugyldig innlogging. Prøv igjen.';
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="no">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Logg inn · Mine verdier</title>
+    <link rel="stylesheet" href="assets/style.css">
+</head>
+<body>
+<main class="shell auth-shell">
+    <section class="card auth-card">
+        <p class="eyebrow">Mine verdier</p>
+        <h1>Logg inn</h1>
+        <p class="muted">Bruk samme bruker som resten av løsningene.</p>
+        <?php if ($error): ?>
+            <div class="alert error"><?php echo htmlspecialchars($error, ENT_QUOTES, 'UTF-8'); ?></div>
+        <?php endif; ?>
+        <form method="POST" action="login.php" class="stacked-form">
+            <label>E-post
+                <input type="email" name="email" autocomplete="email" required>
+            </label>
+            <label>Passord
+                <input type="password" name="password" autocomplete="current-password" required>
+            </label>
+            <button type="submit" class="btn primary">Logg inn</button>
+        </form>
+    </section>
+</main>
+</body>
+</html>

--- a/eiendeler/logout.php
+++ b/eiendeler/logout.php
@@ -1,0 +1,3 @@
+<?php
+require_once __DIR__ . '/auth.php';
+logout_and_redirect();

--- a/eiendeler/schema.sql
+++ b/eiendeler/schema.sql
@@ -1,0 +1,16 @@
+-- SQL schema for personlig eiendels- og verdioversikt
+CREATE TABLE IF NOT EXISTS assets (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    user_id INT NOT NULL,
+    category ENUM('property','crypto','cash','other') NOT NULL,
+    name VARCHAR(120) NOT NULL,
+    provider VARCHAR(120) NULL,
+    gross_value DECIMAL(18,2) NOT NULL DEFAULT 0,
+    ownership_percent DECIMAL(5,2) NOT NULL DEFAULT 100,
+    currency VARCHAR(10) NOT NULL DEFAULT 'NOK',
+    notes TEXT NULL,
+    valuation_date DATE NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_assets_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);

--- a/indexlink.php
+++ b/indexlink.php
@@ -107,6 +107,12 @@
         <p>Analyser avkastning på bolig og egenkapital direkte i nettleseren.</p>
         <a href="boligavkastning/index.html" aria-label="Gå til boligavkastning"></a>
       </div>
+      <div class="card">
+        <div class="tag" style="color:#2563eb;">💼 Verdier</div>
+        <h2>Mine verdier</h2>
+        <p>Logg bolig, krypto, cash og andre eiendeler med verdi, bank/leverandør og eierandel.</p>
+        <a href="eiendeler/index.php" aria-label="Gå til Mine verdier"></a>
+      </div>
     </div>
   </div>
 </body>


### PR DESCRIPTION
### Motivation
- Provide a lightweight, user-scoped web app to track personal assets (property, crypto, cash, other) with value, provider/location and ownership percentage.
- Reuse the existing authentication so users can sign in and manage their own assets and valuations.

### Description
- Added a new app under `eiendeler/` with `index.php`, `actions.php`, `login.php`, `logout.php`, `auth.php`, and `assets/style.css` to implement UI, styling and CRUD actions for assets.
- Added SQL schema `eiendeler/schema.sql` which creates the `assets` table including `user_id`, `category`, `gross_value`, `ownership_percent`, `currency`, `valuation_date`, and timestamps.
- Implemented server-side validation and persistence in `eiendeler/actions.php`, plus net-value calculations (value × ownership percent) and listing/edit/delete flows in `eiendeler/index.php`.
- Linked the new app from the main landing page by adding an entry to `indexlink.php` so it is discoverable from the site index.

### Testing
- Performed syntax checks with `php -l` on `eiendeler/index.php`, `eiendeler/actions.php`, `eiendeler/login.php`, `eiendeler/auth.php`, `eiendeler/logout.php`, and `indexlink.php`, and all files passed with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a39098339b08327842ad428ce66bcc6)